### PR TITLE
rest to md with pandoc

### DIFF
--- a/docs/wemake-python-styleguide/0.15.2/WPS000.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS000.md
@@ -3,13 +3,16 @@ code: 0
 title: Internal error happened, see log. Please, take some time to report it
 ---
 
-
 Happens when we get unhandled exception during the linting process.
 
-All this violations should be reported to the main issue tracker.
-We ideally should not produce these violations at all.
+All this violations should be reported to the main issue tracker. We
+ideally should not produce these violations at all.
 
-See also:
-    https://github.com/wemake-services/wemake-python-styleguide/issues
+  - See also:  
+    <https://github.com/wemake-services/wemake-python-styleguide/issues>
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS100.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS100.md
@@ -3,31 +3,33 @@ code: 100
 title: Found wrong module name
 ---
 
-
 Forbid blacklisted module names.
 
-Reasoning:
-    Some module names are not expressive enough.
-    It is hard to tell what you can find inside the ``utils.py`` module.
+  - Reasoning:  
+    Some module names are not expressive enough. It is hard to tell what
+    you can find inside the `utils.py` module.
 
-Solution:
+  - Solution:  
     Rename your module, reorganize the contents.
 
-See
-:py:data:`~wemake_python_styleguide.constants.MODULE_NAMES_BLACKLIST`
-for the full list of bad module names.
+See :py`~wemake_python_styleguide.constants.MODULE_NAMES_BLACKLIST` for
+the full list of bad module names.
 
-Example::
+Example:
 
     # Correct:
     github.py
     views.py
-
+    
     # Wrong:
     utils.py
     helpers.py
 
-See also:
-    https://tonsky.me/blog/utils/
+  - See also:  
+    <https://tonsky.me/blog/utils/>
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS101.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS101.md
@@ -3,24 +3,27 @@ code: 101
 title: Found wrong module magic name
 ---
 
-
 Forbid magic names (except some whitelisted ones).
 
-Reasoning:
-    Do not fall in love with magic. There's no good reason to use
-    magic names when you can use regular names.
+  - Reasoning:  
+    Do not fall in love with magic. There's no good reason to use magic
+    names when you can use regular names.
 
 See
-:py:data:`~wemake_python_styleguide.constants.MAGIC_MODULE_NAMES_WHITELIST`
+:py`~wemake_python_styleguide.constants.MAGIC_MODULE_NAMES_WHITELIST`
 for the full list of allowed magic module names.
 
-Example::
+Example:
 
     # Correct:
     __init__.py
     __main__.py
-
+    
     # Wrong:
     __version__.py
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS102.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS102.md
@@ -3,29 +3,31 @@ code: 102
 title: Found incorrect module name pattern
 ---
 
-
 Forbid module names that do not match our pattern.
 
-Reasoning:
-    Module names must be valid python identifiers.
-    And just like the variable names - module names should be consistent.
-    Ideally, they should follow the same rules.
-    For ``python`` world it is common to use ``snake_case`` notation.
+  - Reasoning:  
+    Module names must be valid python identifiers. And just like the
+    variable names - module names should be consistent. Ideally, they
+    should follow the same rules. For `python` world it is common to use
+    `snake_case` notation.
 
-We use
-:py:data:`~wemake_python_styleguide.constants.MODULE_NAME_PATTERN`
-to validate the module names.
+We use :py`~wemake_python_styleguide.constants.MODULE_NAME_PATTERN` to
+validate the module names.
 
-Example::
+Example:
 
     # Correct:
     __init__.py
     some_module_name.py
     test12.py
-
+    
     # Wrong:
     _some.py
     MyModule.py
     0001_migration.py
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS110.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS110.md
@@ -28,10 +28,10 @@ Example:
 
   - Configuration:  
     This rule is configurable with `--allowed-domain-names`. Default:
-    `wemake_python_styleguide.options.defaults.ALLOWED_DOMAIN_NAMES`
+    `python://wemake_python_styleguide.options.defaults.ALLOWED_DOMAIN_NAMES`
     
     And with `--forbidden-domain-names`. Default:
-    `wemake_python_styleguide.options.defaults.FORBIDDEN_DOMAIN_NAMES`
+    `python://wemake_python_styleguide.options.defaults.FORBIDDEN_DOMAIN_NAMES`
     
     The options listed above are used to create new variable names'
     blacklist starting from

--- a/docs/wemake-python-styleguide/0.15.2/WPS110.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS110.md
@@ -3,42 +3,42 @@ code: 110
 title: 'Found wrong variable name: {0}'
 ---
 
-
 Forbid blacklisted variable names.
 
-Reasoning:
-    We have found some names that are not expressive enough.
-    However, they appear in the code more than often.
-    All names that we forbid to use could be improved.
+  - Reasoning:  
+    We have found some names that are not expressive enough. However,
+    they appear in the code more than often. All names that we forbid to
+    use could be improved.
 
-Solution:
-    Try to use a more specific name instead.
-    If you really want to use any of the names from the list,
-    add a prefix or suffix to it. It will serve you well.
+  - Solution:  
+    Try to use a more specific name instead. If you really want to use
+    any of the names from the list, add a prefix or suffix to it. It
+    will serve you well.
 
-See
-:py:data:`~wemake_python_styleguide.constants.VARIABLE_NAMES_BLACKLIST`
+See :py`~wemake_python_styleguide.constants.VARIABLE_NAMES_BLACKLIST`
 for the base list of blacklisted variable names.
 
-Example::
+Example:
 
     # Correct:
     html_node_item = None
-
+    
     # Wrong:
     item = None
 
-Configuration:
-    This rule is configurable with ``--allowed-domain-names``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.ALLOWED_DOMAIN_NAMES`
-
-    And with ``--forbidden-domain-names``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.FORBIDDEN_DOMAIN_NAMES`
-
+  - Configuration:  
+    This rule is configurable with `--allowed-domain-names`. Default:
+    `wemake_python_styleguide.options.defaults.ALLOWED_DOMAIN_NAMES`
+    
+    And with `--forbidden-domain-names`. Default:
+    `wemake_python_styleguide.options.defaults.FORBIDDEN_DOMAIN_NAMES`
+    
     The options listed above are used to create new variable names'
     blacklist starting from
-    :py:data:`~wemake_python_styleguide.constants.VARIABLE_NAMES_BLACKLIST`.
+    :py`~wemake_python_styleguide.constants.VARIABLE_NAMES_BLACKLIST`.
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS111.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS111.md
@@ -3,36 +3,49 @@ code: 111
 title: 'Found too short name: {0}'
 ---
 
-
 Forbid short variable or module names.
 
-Reasoning:
+  - Reasoning:  
     It is hard to understand what the variable means and why it is used,
     if its name is too short.
 
-Solution:
+  - Solution:  
     Think of another name. Give more context to it.
 
-This rule checks: modules, variables, attributes,
-functions, methods, and classes.
+This rule checks: modules, variables, attributes, functions, methods,
+and classes.
 
-We do not count trailing and leading underscores when calculating length.
+We do not count trailing and leading underscores when calculating
+length.
 
-Example::
+Example:
 
     # Correct:
     x_coordinate = 1
     abscissa = 2
-
+    
     # Wrong:
     x = 1
     y = 2
 
-Configuration:
-    This rule is configurable with ``--min-name-length``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MIN_NAME_LENGTH`
+  - Configuration:  
+    This rule is configurable with `--min-name-length`. Default:
+    `wemake_python_styleguide.options.defaults.MIN_NAME_LENGTH`
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.4.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.4.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS111.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS111.md
@@ -30,7 +30,7 @@ Example:
 
   - Configuration:  
     This rule is configurable with `--min-name-length`. Default:
-    `wemake_python_styleguide.options.defaults.MIN_NAME_LENGTH`
+    `python://wemake_python_styleguide.options.defaults.MIN_NAME_LENGTH`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS112.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS112.md
@@ -3,29 +3,42 @@ code: 112
 title: 'Found private name pattern: {0}'
 ---
 
-
 Forbid private name pattern.
 
-Reasoning:
-    Private is not private in ``python``.
-    So, why should we pretend it is?
+  - Reasoning:  
+    Private is not private in `python`. So, why should we pretend it is?
     This might lead to some serious design flaws.
 
-Solution:
-    Rename your variable or method to be protected.
-    Think about your design, why do you want to make it private?
-    Are there any other ways to achieve what you want?
+  - Solution:  
+    Rename your variable or method to be protected. Think about your
+    design, why do you want to make it private? Are there any other ways
+    to achieve what you want?
 
-This rule checks: modules, variables, attributes, functions, and methods.
+This rule checks: modules, variables, attributes, functions, and
+methods.
 
-Example::
+Example:
 
     # Correct:
     def _collect_coverage(self): ...
-
+    
     # Wrong:
     def __collect_coverage(self): ...
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.4.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
+
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.4.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS113.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS113.md
@@ -23,7 +23,7 @@ you can reexport things with `as`, because `mypy` might require it with
   - Configuration:  
     This rule is configurable with `--i-control-code` and
     `--i-dont-control-code`. Default:
-    `wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
+    `python://wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS113.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS113.md
@@ -3,31 +3,42 @@ code: 113
 title: 'Found same alias import: {0}'
 ---
 
-
 Forbid using the same alias as the original name in imports.
 
-Reasoning:
+  - Reasoning:  
     Why would you even do this in the first place?
 
-Example::
+Example:
 
     # Correct:
     from os import path
-
+    
     # Wrong:
     from os import path as path
 
-When `--i-control-code` is set to ``False``
-you can reexport things with ``as``,
-because ``mypy`` might require it
-with ``implicit_reexport = False`` setting turned on.
+When <span class="title-ref">--i-control-code</span> is set to `False`
+you can reexport things with `as`, because `mypy` might require it with
+`implicit_reexport = False` setting turned on.
 
-Configuration:
-    This rule is configurable with ``--i-control-code``
-    and ``--i-dont-control-code``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
+  - Configuration:  
+    This rule is configurable with `--i-control-code` and
+    `--i-dont-control-code`. Default:
+    `wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.13.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
+
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.13.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS114.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS114.md
@@ -3,31 +3,39 @@ code: 114
 title: 'Found underscored number name pattern: {0}'
 ---
 
-
 Forbid names with underscored numbers pattern.
 
-Reasoning:
+  - Reasoning:  
     This is done for consistency in naming.
 
-Solution:
-    Do not put an underscore between text and numbers, that is confusing.
-    Rename your variable or modules do not include underscored numbers.
+  - Solution:  
+    Do not put an underscore between text and numbers, that is
+    confusing. Rename your variable or modules do not include
+    underscored numbers.
 
-This rule checks: modules, variables, attributes,
-functions, method, and classes.
-Please, note that putting an underscore that replaces ``-`` in some
-names between numbers are fine, example: ``ISO-123-456`` would become
-``iso123_456``.
+This rule checks: modules, variables, attributes, functions, method, and
+classes. Please, note that putting an underscore that replaces `-` in
+some names between numbers are fine, example: `ISO-123-456` would become
+`iso123_456`.
 
-Example::
+Example:
 
     # Correct:
     star_wars_episode2 = 'awesome!'
     iso123_456 = 'some data'
-
+    
     # Wrong:
     star_wars_episode_2 = 'not so awesome'
     iso_123_456 = 'some data'
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.4.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.4.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS115.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS115.md
@@ -3,26 +3,28 @@ code: 115
 title: 'Found upper-case constant in a class: {0}'
 ---
 
+Require `snake_case` for naming class attributes.
 
-Require ``snake_case`` for naming class attributes.
-
-Reasoning:
+  - Reasoning:  
     Constants with upper-case names belong on a module level.
 
-Solution:
-    Move your constants to the module level.
-    Rename your variables so that they conform
-    to ``snake_case`` convention.
+  - Solution:  
+    Move your constants to the module level. Rename your variables so
+    that they conform to `snake_case` convention.
 
-Example::
+Example:
 
     # Correct:
     MY_MODULE_CONSTANT = 1
     class A(object):
         my_attribute = 42
-
+    
     # Wrong:
     class A(object):
         MY_CONSTANT = 42
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS116.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS116.md
@@ -3,23 +3,32 @@ code: 116
 title: 'Found consecutive underscores name: {0}'
 ---
 
-
 Forbid using more than one consecutive underscore in variable names.
 
-Reasoning:
-    This is done to gain extra readability.
-    This naming rule already exists for module names.
+  - Reasoning:  
+    This is done to gain extra readability. This naming rule already
+    exists for module names.
 
-Example::
+Example:
 
     # Correct:
     some_value = 5
     __magic__ = 5
-
+    
     # Wrong:
     some__value = 5
 
-This rule checks: modules, variables, attributes, functions, and methods.
+This rule checks: modules, variables, attributes, functions, and
+methods.
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.4.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.4.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS117.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS117.md
@@ -3,25 +3,28 @@ code: 117
 title: 'Found name reserved for first argument: {0}'
 ---
 
+Forbid naming variables `self`, `cls`, or `mcs`.
 
-Forbid naming variables ``self``, ``cls``, or ``mcs``.
+  - Reasoning:  
+    These names are special, they should only be used as first arguments
+    inside methods.
 
-Reasoning:
-    These names are special, they should only be used as first
-    arguments inside methods.
-
-Example::
+Example:
 
     # Correct:
     class Test(object):
         def __init__(self):
             ...
-
+    
     # Wrong:
     cls = 5
     lambda self: self + 12
 
-This rule checks: functions and methods.
-Having any reserved names in ``lambda`` functions is not allowed.
+This rule checks: functions and methods. Having any reserved names in
+`lambda` functions is not allowed.
 
-.. versionadded:: 0.5.0
+<div class="versionadded">
+
+0.5.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS118.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS118.md
@@ -28,7 +28,7 @@ Example:
 
   - Configuration:  
     This rule is configurable with `--max-name-length`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_NAME_LENGTH`
+    `python://wemake_python_styleguide.options.defaults.MAX_NAME_LENGTH`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS118.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS118.md
@@ -3,34 +3,35 @@ code: 118
 title: 'Found too long name: {0}'
 ---
 
-
 Forbid long variable or module names.
 
-Reasoning:
-    Too long names are unreadable.
-    It is better to use a shorter alternative.
-    Long names also indicate that this variable is too complex,
-    maybe it may require some documentation.
+  - Reasoning:  
+    Too long names are unreadable. It is better to use a shorter
+    alternative. Long names also indicate that this variable is too
+    complex, maybe it may require some documentation.
 
-Solution:
+  - Solution:  
     Think of another name. Give less context to it.
 
-This rule checks: modules, variables, attributes,
-functions, methods, and classes.
+This rule checks: modules, variables, attributes, functions, methods,
+and classes.
 
-Example::
+Example:
 
     # Correct:
     total_price = 25
     average_age = 45
-
+    
     # Wrong:
     final_price_after_fifteen_percent_sales_tax_and_gratuity = 30
     total_age_of_all_participants_in_the_survey_divided_by_twelve = 2
 
-Configuration:
-    This rule is configurable with ``--max-name-length``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_NAME_LENGTH`
+  - Configuration:  
+    This rule is configurable with `--max-name-length`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_NAME_LENGTH`
 
-.. versionadded:: 0.5.0
+<div class="versionadded">
+
+0.5.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS119.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS119.md
@@ -3,25 +3,28 @@ code: 119
 title: 'Found unicode name: {0}'
 ---
 
-
 Forbid unicode names.
 
-Reasoning:
+  - Reasoning:  
     This should be forbidden for sanity, readability, and writability.
 
-Solution:
+  - Solution:  
     Rename your entities so that they contain only ASCII symbols.
 
-This rule checks: modules, variables, attributes,
-functions, methods, and classes.
+This rule checks: modules, variables, attributes, functions, methods,
+and classes.
 
-Example::
+Example:
 
     # Correct:
     some_variable = 'Text with russian: русский язык'
-
+    
     # Wrong:
     переменная = 42
     some_變量 = ''
 
-.. versionadded:: 0.5.0
+<div class="versionadded">
+
+0.5.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS120.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS120.md
@@ -3,27 +3,30 @@ code: 120
 title: 'Found regular name with trailing underscore: {0}'
 ---
 
+Forbid trailing `_` for names that do not need it.
 
-Forbid trailing ``_`` for names that do not need it.
+  - Reasoning:  
+    We use trailing underscore for a reason: to indicate that this name
+    shadows a built-in or keyword. So, when overusing this feature for
+    general names: it just harms readability of your program.
 
-Reasoning:
-    We use trailing underscore for a reason:
-    to indicate that this name shadows a built-in or keyword.
-    So, when overusing this feature for general names:
-    it just harms readability of your program.
-
-Solution:
+  - Solution:  
     Rename your variable not to contain trailing underscores.
 
-This rule checks: variables, attributes, functions, methods, and classes.
+This rule checks: variables, attributes, functions, methods, and
+classes.
 
-Example::
+Example:
 
     # Correct:
     class_ = SomeClass
     list_ = []
-
+    
     # Wrong:
     some_variable_ = 1
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS121.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS121.md
@@ -3,41 +3,53 @@ code: 121
 title: 'Found usage of a variable marked as unused: {0}'
 ---
 
-
 Forbid using variables that are marked as unused.
 
-We discourage using variables that start with ``_``
-only inside functions and methods as local variables.
+We discourage using variables that start with `_` only inside functions
+and methods as local variables.
 
-However, we allow to use ``_`` because tools like
-``ipython``, ``babel``, and ``django`` enforce it.
+However, we allow to use `_` because tools like `ipython`, `babel`, and
+`django` enforce it.
 
-Reasoning:
-    Sometimes you start to use new logic in your functions,
-    and you start to use variables that once were marked as unused.
-    But, you have not renamed them for some reason.
-    And now you have a lot of confusion: the variable is marked as unused,
-    but you are using it. Why? What's going on?
+  - Reasoning:  
+    Sometimes you start to use new logic in your functions, and you
+    start to use variables that once were marked as unused. But, you
+    have not renamed them for some reason. And now you have a lot of
+    confusion: the variable is marked as unused, but you are using it.
+    Why? What's going on?
 
- Solution:
-    Rename your variable to be a regular variable
-    without a leading underscore.
-    This way it is declared to be used.
+  - Solution:  
+    Rename your variable to be a regular variable without a leading
+    underscore. This way it is declared to be used.
 
- Example::
+> Example:
+> 
+>     # Correct:
+>     def function():
+>         first = 15
+>         return first + 10
+>     
+>     # Wrong:
+>     def function():
+>         _first = 15
+>         return _first + 10
 
-    # Correct:
-    def function():
-        first = 15
-        return first + 10
+This rule checks: functions, methods, and `lambda` functions.
 
-    # Wrong:
-    def function():
-        _first = 15
-        return _first + 10
+<div class="versionadded">
 
-This rule checks: functions, methods, and ``lambda`` functions.
+0.7.0
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.12.0
-.. versionchanged:: 0.14.0
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS122.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS122.md
@@ -3,30 +3,33 @@ code: 122
 title: 'Found all unused variables definition: {0}'
 ---
 
-
 Forbid explicit unused variables.
 
-Reasoning:
-    While it is ok to define unused variables when you have to,
-    like when unpacking a tuple, it is totally not ok to define explicit
+  - Reasoning:  
+    While it is ok to define unused variables when you have to, like
+    when unpacking a tuple, it is totally not ok to define explicit
     unusued variables in cases like assignment, function return,
-    exception handling, or context managers.
-    Why do you need this explicitly unused variables?
+    exception handling, or context managers. Why do you need this
+    explicitly unused variables?
 
-Solution:
+  - Solution:  
     Remove all unused variables definition.
 
-Example::
+Example:
 
     # Correct:
     my_function()
     first, _second = some_tuple()
     print(first)
-
+    
     # Wrong:
     _ = my_function()
     _first, _second = some_tuple()
 
 This rule checks: assigns, context managers, except clauses.
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS123.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS123.md
@@ -3,25 +3,29 @@ code: 123
 title: 'Found wrong unused variable name: {0}'
 ---
 
-
 Forbid unused variables with multiple underscores.
 
-Reasoning:
-    We only use ``_`` as a special definition for an unused variable.
-    Other variables are hard to read. It is unclear why would one use it.
+  - Reasoning:  
+    We only use `_` as a special definition for an unused variable.
+    Other variables are hard to read. It is unclear why would one use
+    it.
 
-Solution:
-    Rename unused variables to ``_``
-    or give it some more context with an explicit name: ``_context``.
+  - Solution:  
+    Rename unused variables to `_` or give it some more context with an
+    explicit name: `_context`.
 
-Example::
+Example:
 
     # Correct:
     some_element, _next_element, _ = some_tuple()
     some_element, _, _ = some_tuple()
     some_element, _ = some_tuple()
-
+    
     # Wrong:
     some_element, _, __  = some_tuple()
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS124.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS124.md
@@ -3,31 +3,34 @@ code: 124
 title: 'Found unreadable characters combination: {0}'
 ---
 
-
 Forbid variable or module names which could be difficult to read.
 
-Reasoning:
-    Currently one can name your classes like so: ``ZerO0``
-    Inside it is just ``O`` and ``0``, but we cannot tell it from the word.
-    There are a lot other combinations which are unreadable.
+  - Reasoning:  
+    Currently one can name your classes like so: `ZerO0` Inside it is
+    just `O` and `0`, but we cannot tell it from the word. There are a
+    lot other combinations which are unreadable.
 
-Solution:
+  - Solution:  
     Rename your entity not to contain unreadable sequences.
 
-This rule checks: modules, variables, attributes,
-functions, methods, and classes.
+This rule checks: modules, variables, attributes, functions, methods,
+and classes.
 
 See
-:py:data:`~wemake_python_styleguide.constants.UNREADABLE_CHARACTER_COMBINATIONS`
+:py`~wemake_python_styleguide.constants.UNREADABLE_CHARACTER_COMBINATIONS`
 for full list of unreadable combinations.
 
-Example::
+Example:
 
     # Correct:
     ControlStatement
     AveragePrice
-
+    
     # Wrong:
     Memo0Output
 
-.. versionadded:: 0.14
+<div class="versionadded">
+
+0.14
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS125.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS125.md
@@ -3,38 +3,47 @@ code: 125
 title: 'Found builtin shadowing: {0}'
 ---
 
-
 Forbid variable or module names which shadow builtin names.
 
-Reasoning:
-    Your code simply breaks Python. After you create ``list = 1``,
-    you cannot not call ``builtin`` function ``list``
-    and what can be worse than that?
+  - Reasoning:  
+    Your code simply breaks Python. After you create `list = 1`, you
+    cannot not call `builtin` function `list` and what can be worse than
+    that?
 
-Solution:
+  - Solution:  
     Rename your entity to not shadow Python builtins.
 
-Example::
+Example:
 
     # Correct:
     my_list = list(some_other)
-
+    
     # Wrong:
     str = ''
     list = [1, 2, 3]
 
-This can also cause problems when defining class attributes, for example::
+This can also cause problems when defining class attributes, for
+example:
 
     class A:
         min = 5
         max = min(10, 20)  # TypeError: 'int' object is not callable
 
 If you feel it is still necessary to use such a class attribute,
-consider using a `noqa` comment with caution.
+consider using a <span class="title-ref">noqa</span> comment with
+caution.
 
-See
-:py:data:`~wemake_python_styleguide.constants.BUILTINS_WHITELIST`
-for full list of builtins we allow to shadow.
+See :py`~wemake_python_styleguide.constants.BUILTINS_WHITELIST` for full
+list of builtins we allow to shadow.
 
-.. versionadded:: 0.14
-.. versionchanged:: 0.15
+<div class="versionadded">
+
+0.14
+
+</div>
+
+<div class="versionchanged">
+
+0.15
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS200.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS200.md
@@ -3,27 +3,28 @@ code: 200
 title: 'Found module with high Jones Complexity score: {0}'
 ---
 
-
 Forbid modules with complex lines.
 
-We are using the Jones Complexity algorithm to count module's score.
-See
-:py:class:`~.LineComplexityViolation` for details of per-line-complexity.
-How it is done: we count complexity per line, then measure the median
+We are using the Jones Complexity algorithm to count module's score. See
+:py`~.LineComplexityViolation` for details of per-line-complexity. How
+it is done: we count complexity per line, then measure the median
 complexity across the lines in the whole module.
 
-Reasoning:
+  - Reasoning:  
     Having complex modules will decrease your code maintainability.
 
-Solution:
+  - Solution:  
     Refactor the module contents.
 
-Configuration:
-    This rule is configurable with ``--max-jones-score``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_JONES_SCORE`
+  - Configuration:  
+    This rule is configurable with `--max-jones-score`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_JONES_SCORE`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
 
-See also:
-    https://github.com/Miserlou/JonesComplexity
+0.1.0
+
+</div>
+
+  - See also:  
+    <https://github.com/Miserlou/JonesComplexity>

--- a/docs/wemake-python-styleguide/0.15.2/WPS200.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS200.md
@@ -18,7 +18,7 @@ complexity across the lines in the whole module.
 
   - Configuration:  
     This rule is configurable with `--max-jones-score`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_JONES_SCORE`
+    `python://wemake_python_styleguide.options.defaults.MAX_JONES_SCORE`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS201.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS201.md
@@ -30,7 +30,7 @@ We do not make any distinction between `import` and `from ... import
 
   - Configuration:  
     This rule is configurable with `--max-imports`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_IMPORTS`
+    `python://wemake_python_styleguide.options.defaults.MAX_IMPORTS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS201.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS201.md
@@ -3,34 +3,37 @@ code: 201
 title: 'Found module with too many imports: {0}'
 ---
 
-
 Forbid modules with too many imports.
 
-Namespaces are one honking great idea -- let's do more of those!
+Namespaces are one honking great idea -- let's do more of those\!
 
-Reasoning:
-    Having too many imports without prefixes is quite expensive.
-    You have to memorize all the source locations of the imports
-    and sometimes it is hard to remember what kind of functions and classes
+  - Reasoning:  
+    Having too many imports without prefixes is quite expensive. You
+    have to memorize all the source locations of the imports and
+    sometimes it is hard to remember what kind of functions and classes
     are already injected into your context.
-
+    
     It is also a questionable design if a single module has a lot of
-    imports. Why would a single module have so many dependencies?
-    So, the module becomes too coupled.
+    imports. Why would a single module have so many dependencies? So,
+    the module becomes too coupled.
 
-Solution:
+  - Solution:  
     Refactor the imports to import a common namespace. Something like
-    ``from package import module`` and then
-    use it like ``module.function()``.
+    `from package import module` and then use it like
+    `module.function()`.
+    
+    Or refactor your code and split the complex module into several
+    modules.
 
-    Or refactor your code and split the complex module
-    into several modules.
+We do not make any distinction between `import` and `from ... import
+...`.
 
-We do not make any distinction between
-``import`` and ``from ... import ...``.
+  - Configuration:  
+    This rule is configurable with `--max-imports`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_IMPORTS`
 
-Configuration:
-    This rule is configurable with ``--max-imports``.
-    Default: :str:`wemake_python_styleguide.options.defaults.MAX_IMPORTS`
+<div class="versionadded">
 
-.. versionadded:: 0.1.0
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS202.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS202.md
@@ -3,24 +3,26 @@ code: 202
 title: 'Found too many module members: {0}'
 ---
 
-
 Forbid too many classes and functions in a single module.
 
-Reasoning:
+  - Reasoning:  
     Having many classes and functions in a single module is a bad thing.
     Soon it will be hard to read through this code and understand it.
 
-Solution:
+  - Solution:  
     It is better to split this module into several modules or a package.
 
-We do not make any distinctions between classes and functions in this check.
-They are treated as the same unit of logic.
-We also do not care about functions and classes being public or not.
-However, methods are counted separately on a per-class basis.
+We do not make any distinctions between classes and functions in this
+check. They are treated as the same unit of logic. We also do not care
+about functions and classes being public or not. However, methods are
+counted separately on a per-class basis.
 
-Configuration:
-    This rule is configurable with ``--max-module-members``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_MODULE_MEMBERS`
+  - Configuration:  
+    This rule is configurable with `--max-module-members`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_MODULE_MEMBERS`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS202.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS202.md
@@ -19,7 +19,7 @@ counted separately on a per-class basis.
 
   - Configuration:  
     This rule is configurable with `--max-module-members`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_MODULE_MEMBERS`
+    `python://wemake_python_styleguide.options.defaults.MAX_MODULE_MEMBERS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS203.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS203.md
@@ -38,7 +38,7 @@ We do not make any differences between `import` and `from ... import
 
   - Configuration:  
     This rule is configurable with `--max-imported-names`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_IMPORTED_NAMES`
+    `python://wemake_python_styleguide.options.defaults.MAX_IMPORTED_NAMES`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS203.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS203.md
@@ -3,42 +3,45 @@ code: 203
 title: 'Found module with too many imported names: {0}'
 ---
 
-
 Forbid modules with too many imported names.
 
-Namespaces are one honking great idea -- let's do more of those!
+Namespaces are one honking great idea -- let's do more of those\!
 
-Reasoning:
+  - Reasoning:  
     Having too many imported names without prefixes is quite expensive.
-    You have to memorize all the source locations of the imports
-    and sometimes it is hard to remember what kind of functions and classes
+    You have to memorize all the source locations of the imports and
+    sometimes it is hard to remember what kind of functions and classes
     are already injected into your context.
-
+    
     It is also a questionable design if a single module has a lot of
-    imports. Why would a single module have so many dependencies?
-    So, the module becomes too coupled.
+    imports. Why would a single module have so many dependencies? So,
+    the module becomes too coupled.
 
-Solution:
+  - Solution:  
     Refactor the imports to import a common namespace. Something like
-    ``from package import module`` and then
-    use it like ``module.function()``.
+    `from package import module` and then use it like
+    `module.function()`.
+    
+    Or refactor your code and split the complex module into several
+    modules.
 
-    Or refactor your code and split the complex module into several modules.
-
-Example::
+Example:
 
     # Correct:
     import module  # 1 imported name
-
+    
     # Wrong:
     from module import func1, func2, ..., funcN  # N imported names
 
-We do not make any differences between
-``import`` and ``from ... import ...``.
+We do not make any differences between `import` and `from ... import
+...`.
 
-Configuration:
-    This rule is configurable with ``--max-imported-names``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_IMPORTED_NAMES`
+  - Configuration:  
+    This rule is configurable with `--max-imported-names`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_IMPORTED_NAMES`
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS204.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS204.md
@@ -28,10 +28,10 @@ Related to `~TooManyExpressionsViolation`.
 
   - Configuration:  
     This rule is configurable with `--max-module-expressions`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_MODULE_EXPRESSIONS`
+    `python://wemake_python_styleguide.options.defaults.MAX_MODULE_EXPRESSIONS`
     
     And with `--max-function-expressions`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_FUNCTION_EXPRESSIONS`
+    `python://wemake_python_styleguide.options.defaults.MAX_FUNCTION_EXPRESSIONS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS204.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS204.md
@@ -3,37 +3,44 @@ code: 204
 title: 'Found overused expression: {0}'
 ---
 
-
 Forbid overused expressions in a module, function or method.
 
 What do we call an "overused expression"? When you use any expression
-(like ``user_dict['age']`` for example) inside your code,
-you always have to track that you are not using it "too much"
-because if that expression is everywhere inside your code,
-it is a sign of a problem. It means that you are missing an abstraction.
+(like `user_dict['age']` for example) inside your code, you always have
+to track that you are not using it "too much" because if that expression
+is everywhere inside your code, it is a sign of a problem. It means that
+you are missing an abstraction.
 
 We check for overused expressions on two levels:
 
-- per each function
-- per all module
+  - per each function
+  - per all module
 
-Related to :class:`~TooManyExpressionsViolation`.
+Related to `~TooManyExpressionsViolation`.
 
-Reasoning:
+  - Reasoning:  
     Overusing expressions leads to losing the parts that can and should
     be refactored into variables, methods, and properties of objects.
 
-Solution:
-    Refactor expressions to be an attribute, a method, or a new variable.
+  - Solution:  
+    Refactor expressions to be an attribute, a method, or a new
+    variable.
 
-Configuration:
-    This rule is configurable with ``--max-module-expressions``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_MODULE_EXPRESSIONS`
+  - Configuration:  
+    This rule is configurable with `--max-module-expressions`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_MODULE_EXPRESSIONS`
+    
+    And with `--max-function-expressions`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_FUNCTION_EXPRESSIONS`
 
-    And with ``--max-function-expressions``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_FUNCTION_EXPRESSIONS`
+<div class="versionadded">
 
-.. versionadded:: 0.12.0
-.. versionchanged:: 0.14.0
+0.12.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS210.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS210.md
@@ -41,7 +41,7 @@ variable. Since by design it means: do not count me as a real variable.
 
   - Configuration:  
     This rule is configurable with `--max-local-variables`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_LOCAL_VARIABLES`
+    `python://wemake_python_styleguide.options.defaults.MAX_LOCAL_VARIABLES`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS210.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS210.md
@@ -3,27 +3,27 @@ code: 210
 title: 'Found too many local variables: {0}'
 ---
 
-
 Forbid too many local variables in the unit of code.
 
-Reasoning:
-    Having too many variables in a single function is a bad thing.
-    Soon, you will have trouble understanding what this variable means.
-    It will also become hard to name new variables.
+  - Reasoning:  
+    Having too many variables in a single function is a bad thing. Soon,
+    you will have trouble understanding what this variable means. It
+    will also become hard to name new variables.
 
-Solution:
-    If you have too many variables in a function, you have to refactor it.
+  - Solution:  
+    If you have too many variables in a function, you have to refactor
+    it.
 
-What counts as a local variable? We only count a variable as local
-in the following case: it is assigned inside the function body.
-We do not count variables defined inside comprehensions as local variables,
-since it is impossible to use them outside of the comprehension.
+What counts as a local variable? We only count a variable as local in
+the following case: it is assigned inside the function body. We do not
+count variables defined inside comprehensions as local variables, since
+it is impossible to use them outside of the comprehension.
 
-Example::
+Example:
 
     def first_function(param):
         first_var = 1
-
+    
     def second_function(argument):
         second_var = 1
         argument = int(argument)
@@ -31,17 +31,20 @@ Example::
 
 In this example we will count as locals only several variables:
 
-1. ``first_var``, because it is assigned inside the function's body
-2. ``second_var``, because it is assigned inside the function's body
-3. ``argument``, because it is reassigned inside the function's body
-4. ``third_var``, because it is assigned inside the function's body
+1.  `first_var`, because it is assigned inside the function's body
+2.  `second_var`, because it is assigned inside the function's body
+3.  `argument`, because it is reassigned inside the function's body
+4.  `third_var`, because it is assigned inside the function's body
 
-Please, note that ``_`` is a special case. It is not counted as a local
+Please, note that `_` is a special case. It is not counted as a local
 variable. Since by design it means: do not count me as a real variable.
 
-Configuration:
-    This rule is configurable with ``--max-local-variables``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_LOCAL_VARIABLES`
+  - Configuration:  
+    This rule is configurable with `--max-local-variables`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_LOCAL_VARIABLES`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS211.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS211.md
@@ -16,7 +16,7 @@ Forbid too many arguments for a function or method.
 
   - Configuration:  
     This rule is configurable with `--max-arguments`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_ARGUMENTS`
+    `python://wemake_python_styleguide.options.defaults.MAX_ARGUMENTS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS211.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS211.md
@@ -3,20 +3,23 @@ code: 211
 title: 'Found too many arguments: {0}'
 ---
 
-
 Forbid too many arguments for a function or method.
 
-Reasoning:
+  - Reasoning:  
     This is an indicator of a bad design. When a function requires many
-    arguments it is a sign that it should be refactored.
-    It also indicates that the function does too many things at once.
+    arguments it is a sign that it should be refactored. It also
+    indicates that the function does too many things at once.
 
-Solution:
-    Split the function into several functions.
-    Then it will be easier to use them.
+  - Solution:  
+    Split the function into several functions. Then it will be easier to
+    use them.
 
-Configuration:
-    This rule is configurable with ``--max-arguments``.
-    Default: :str:`wemake_python_styleguide.options.defaults.MAX_ARGUMENTS`
+  - Configuration:  
+    This rule is configurable with `--max-arguments`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_ARGUMENTS`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS212.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS212.md
@@ -15,7 +15,7 @@ Forbid placing too many `return` statements in a function.
 
   - Configuration:  
     This rule is configurable with `--max-returns`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_RETURNS`
+    `python://wemake_python_styleguide.options.defaults.MAX_RETURNS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS212.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS212.md
@@ -3,19 +3,22 @@ code: 212
 title: 'Found too many return statements: {0}'
 ---
 
+Forbid placing too many `return` statements in a function.
 
-Forbid placing too many ``return`` statements in a function.
+  - Reasoning:  
+    When there are too many `return` keywords, functions are hard to
+    test. They are also hard to read and hard to change and keep
+    everything inside your head at once.
 
-Reasoning:
-    When there are too many ``return`` keywords,
-    functions are hard to test. They are also hard to read and
-    hard to change and keep everything inside your head at once.
-
-Solution:
+  - Solution:  
     Change your design. Split the function into multiple functions.
 
-Configuration:
-    This rule is configurable with ``--max-returns``.
-    Default: :str:`wemake_python_styleguide.options.defaults.MAX_RETURNS`
+  - Configuration:  
+    This rule is configurable with `--max-returns`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_RETURNS`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS213.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS213.md
@@ -3,29 +3,31 @@ code: 213
 title: 'Found too many expressions: {0}'
 ---
 
-
 Forbid putting too many expressions in a single function.
 
-This rule is quite similar to "max lines" in a function,
-but is much nicer because we don't count lines,
-we count real code entities. This way adding just several extra empty
-lines for readability will never trigger this violation.
+This rule is quite similar to "max lines" in a function, but is much
+nicer because we don't count lines, we count real code entities. This
+way adding just several extra empty lines for readability will never
+trigger this violation.
 
-Related to :class:`~OverusedExpressionViolation`.
+Related to `~OverusedExpressionViolation`.
 
-Reasoning:
-    When there are too many expressions it means that this
-    function does too many things at once. It has too much logic.
+  - Reasoning:  
+    When there are too many expressions it means that this function does
+    too many things at once. It has too much logic.
 
-Solution:
+  - Solution:  
     Split function into several functions, refactor your API.
 
-Configuration:
-    This rule is configurable with ``--max-expressions``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_EXPRESSIONS`
+  - Configuration:  
+    This rule is configurable with `--max-expressions`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_EXPRESSIONS`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
 
-See also:
-    https://en.wikipedia.org/wiki/Expression_(computer_science)
+0.1.0
+
+</div>
+
+  - See also:  
+    <https://en.wikipedia.org/wiki/Expression_(computer_science)>

--- a/docs/wemake-python-styleguide/0.15.2/WPS213.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS213.md
@@ -21,7 +21,7 @@ Related to `~OverusedExpressionViolation`.
 
   - Configuration:  
     This rule is configurable with `--max-expressions`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_EXPRESSIONS`
+    `python://wemake_python_styleguide.options.defaults.MAX_EXPRESSIONS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS214.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS214.md
@@ -3,30 +3,33 @@ code: 214
 title: 'Found too many methods: {0}'
 ---
 
-
 Forbid too many methods in a single class.
 
-Reasoning:
+  - Reasoning:  
     Having too many methods might lead to the "God object" anti-pattern.
-    This kind of object can handle everything.
-    So, in the end, your code becomes too hard to maintain and test.
+    This kind of object can handle everything. So, in the end, your code
+    becomes too hard to maintain and test.
 
-Solution:
-    What to do if you have too many methods in a single class?
-    Split this class into several classes,
-    then use composition or inheritance to refactor your code.
-    This will protect you from the "God object" anti-pattern.
+  - Solution:  
+    What to do if you have too many methods in a single class? Split
+    this class into several classes, then use composition or inheritance
+    to refactor your code. This will protect you from the "God object"
+    anti-pattern.
 
-We do not make any distinctions between instance and class methods.
-We also do not care about functions and classes being public or not.
-We also do not count inherited methods from parents.
-This rule does not count the attributes of a class.
+We do not make any distinctions between instance and class methods. We
+also do not care about functions and classes being public or not. We
+also do not count inherited methods from parents. This rule does not
+count the attributes of a class.
 
-Configuration:
-    This rule is configurable with ``--max-methods``.
-    Default: :str:`wemake_python_styleguide.options.defaults.MAX_METHODS`
+  - Configuration:  
+    This rule is configurable with `--max-methods`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_METHODS`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
 
-See also:
-    https://en.wikipedia.org/wiki/God_object
+0.1.0
+
+</div>
+
+  - See also:  
+    <https://en.wikipedia.org/wiki/God_object>

--- a/docs/wemake-python-styleguide/0.15.2/WPS214.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS214.md
@@ -23,7 +23,7 @@ count the attributes of a class.
 
   - Configuration:  
     This rule is configurable with `--max-methods`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_METHODS`
+    `python://wemake_python_styleguide.options.defaults.MAX_METHODS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS215.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS215.md
@@ -3,41 +3,45 @@ code: 215
 title: 'Too many base classes: {0}'
 ---
 
-
 Restrict the maximum number of base classes.
 
-Reasoning:
-    It is almost never possible to navigate
-    to the desired method of a parent class
-    when you need it with multiple mixins.
-    It is hard to understand ``mro`` and ``super`` calls.
-    Do not overuse this technique.
+  - Reasoning:  
+    It is almost never possible to navigate to the desired method of a
+    parent class when you need it with multiple mixins. It is hard to
+    understand `mro` and `super` calls. Do not overuse this technique.
 
-Solution:
-    Reduce the number of base classes.
-    Use composition over inheritance.
+  - Solution:  
+    Reduce the number of base classes. Use composition over inheritance.
 
-Example::
+Example:
 
-   # Correct:
-   class SomeClassName(First, Second, Mixin): ...
+    # Correct:
+    class SomeClassName(First, Second, Mixin): ...
+    
+    # Wrong:
+    class SomeClassName(
+        FirstParentClass,
+        SecondParentClass,
+        ThirdParentClass,
+        CustomClass,
+        AddedClass,
+     ): ...
 
-   # Wrong:
-   class SomeClassName(
-       FirstParentClass,
-       SecondParentClass,
-       ThirdParentClass,
-       CustomClass,
-       AddedClass,
-    ): ...
+  - Configuration:  
+    This rule is configurable with `--max-base-classes`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_BASE_CLASSES`
 
-Configuration:
-    This rule is configurable with ``--max-base-classes``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_BASE_CLASSES`
+<div class="versionadded">
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.5.0
+0.3.0
 
-See also:
-    https://en.wikipedia.org/wiki/Composition_over_inheritance
+</div>
+
+<div class="versionchanged">
+
+0.5.0
+
+</div>
+
+  - See also:  
+    <https://en.wikipedia.org/wiki/Composition_over_inheritance>

--- a/docs/wemake-python-styleguide/0.15.2/WPS215.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS215.md
@@ -29,7 +29,7 @@ Example:
 
   - Configuration:  
     This rule is configurable with `--max-base-classes`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_BASE_CLASSES`
+    `python://wemake_python_styleguide.options.defaults.MAX_BASE_CLASSES`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS216.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS216.md
@@ -3,27 +3,28 @@ code: 216
 title: 'Too many decorators: {0}'
 ---
 
-
 Restrict the maximum number of decorators.
 
-Reasoning:
-    When you are using too many decorators it means that
-    you are trying to overuse the magic.
-    You have to ask yourself: do I really know what happens inside
-    this decorator tree? Typically, the answer will be "no".
+  - Reasoning:  
+    When you are using too many decorators it means that you are trying
+    to overuse the magic. You have to ask yourself: do I really know
+    what happens inside this decorator tree? Typically, the answer will
+    be "no".
 
-Solution:
-    Using too many decorators typically means that
-    you are trying to configure the behavior from outside of the class.
-    Do not do that too much.
-    Split functions or classes into smaller ones.
-    Use higher order decorators.
+  - Solution:  
+    Using too many decorators typically means that you are trying to
+    configure the behavior from outside of the class. Do not do that too
+    much. Split functions or classes into smaller ones. Use higher order
+    decorators.
 
-Configuration:
-    This rule is configurable with ``--max-decorators``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_DECORATORS`
+  - Configuration:  
+    This rule is configurable with `--max-decorators`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_DECORATORS`
 
 This rule checks: functions, methods, and classes.
 
-.. versionadded:: 0.5.0
+<div class="versionadded">
+
+0.5.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS216.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS216.md
@@ -19,7 +19,7 @@ Restrict the maximum number of decorators.
 
   - Configuration:  
     This rule is configurable with `--max-decorators`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_DECORATORS`
+    `python://wemake_python_styleguide.options.defaults.MAX_DECORATORS`
 
 This rule checks: functions, methods, and classes.
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS217.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS217.md
@@ -3,19 +3,22 @@ code: 217
 title: 'Found too many await expressions: {0}'
 ---
 
+Forbid placing too many `await` expressions in a function.
 
-Forbid placing too many ``await`` expressions in a function.
+  - Reasoning:  
+    When there are too many `await` keywords, functions are starting to
+    get really complex. It is hard to tell where we are and what is
+    going on.
 
-Reasoning:
-    When there are too many ``await`` keywords,
-    functions are starting to get really complex.
-    It is hard to tell where we are and what is going on.
-
-Solution:
+  - Solution:  
     Change your design. Split functions into smaller ones.
 
-Configuration:
-    This rule is configurable with ``--max-awaits``.
-    Default: :str:`wemake_python_styleguide.options.defaults.MAX_AWAITS`
+  - Configuration:  
+    This rule is configurable with `--max-awaits`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_AWAITS`
 
-.. versionadded:: 0.10.0
+<div class="versionadded">
+
+0.10.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS217.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS217.md
@@ -15,7 +15,7 @@ Forbid placing too many `await` expressions in a function.
 
   - Configuration:  
     This rule is configurable with `--max-awaits`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_AWAITS`
+    `python://wemake_python_styleguide.options.defaults.MAX_AWAITS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS218.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS218.md
@@ -3,20 +3,23 @@ code: 218
 title: 'Found too many `assert` statements: {0}'
 ---
 
+Forbid placing too many `assert` statements into a function.
 
-Forbid placing too many ``assert`` statements into a function.
+  - Reasoning:  
+    When there are too many `assert` keywords, functions are starting to
+    get really complex. It might indicate that your tests or contracts
+    are too big.
 
-Reasoning:
-    When there are too many ``assert`` keywords,
-    functions are starting to get really complex.
-    It might indicate that your tests or contracts are too big.
+  - Solution:  
+    Create rich `assert` statements, use higher-level contracts, or
+    create special guard functions.
 
-Solution:
-    Create rich ``assert`` statements, use higher-level contracts,
-    or create special guard functions.
+  - Configuration:  
+    This rule is configurable with `--max-asserts`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_ASSERTS`
 
-Configuration:
-    This rule is configurable with ``--max-asserts``.
-    Default: :str:`wemake_python_styleguide.options.defaults.MAX_ASSERTS`
+<div class="versionadded">
 
-.. versionadded:: 0.12.0
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS218.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS218.md
@@ -16,7 +16,7 @@ Forbid placing too many `assert` statements into a function.
 
   - Configuration:  
     This rule is configurable with `--max-asserts`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_ASSERTS`
+    `python://wemake_python_styleguide.options.defaults.MAX_ASSERTS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS219.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS219.md
@@ -3,36 +3,35 @@ code: 219
 title: 'Found too deep access level: {0}'
 ---
 
-
 Forbid consecutive expressions with too deep access level.
 
 We consider only these expressions as accesses:
 
-- ``ast.Subscript``
-- ``ast.Attribute``
+  - `ast.Subscript`
+  - `ast.Attribute`
 
-We do not treat ``ast.Call`` as an access, since there are
-a lot of call-based APIs like Django ORM, builder patterns, etc.
+We do not treat `ast.Call` as an access, since there are a lot of
+call-based APIs like Django ORM, builder patterns, etc.
 
-Reasoning:
-    Having too deep access level indicates a bad design
-    and overcomplicated data without proper API.
+  - Reasoning:  
+    Having too deep access level indicates a bad design and
+    overcomplicated data without proper API.
 
-Solution:
-    Split the expression into variables, functions or classes.
-    Refactor the API for your data layout.
+  - Solution:  
+    Split the expression into variables, functions or classes. Refactor
+    the API for your data layout.
 
-Example::
+Example:
 
     # Correct: access level = 4
     self.attr.inner.wrapper[1]
-
+    
     # Correct: access level = 1
     manager.filter().exclude().annotate().values().first()
-
+    
     # Wrong: access level = 5
     self.attr.inner.wrapper.method.call()
-
+    
     # Wrong: access level = 5
     # `obj` has access level of 2:
     # `.attr`, `.call`
@@ -40,9 +39,12 @@ Example::
     # `.other`, `[0]`, `.field`, `.type`, `.boom`
     obj.attr.call().other[0].field.type.boom
 
-Configuration:
-    This rule is configurable with ``--max-access-level``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_ACCESS_LEVEL`
+  - Configuration:  
+    This rule is configurable with `--max-access-level`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_ACCESS_LEVEL`
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS219.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS219.md
@@ -41,7 +41,7 @@ Example:
 
   - Configuration:  
     This rule is configurable with `--max-access-level`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_ACCESS_LEVEL`
+    `python://wemake_python_styleguide.options.defaults.MAX_ACCESS_LEVEL`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS220.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS220.md
@@ -3,17 +3,25 @@ code: 220
 title: 'Found too deep nesting: {0}'
 ---
 
-
 Forbid nesting blocks too deep.
 
-Reasoning:
-    If nesting is too deep that indicates usage of complex logic
-    and language constructions. This means that our design is not
-    suited to handle such construction.
+  - Reasoning:  
+    If nesting is too deep that indicates usage of complex logic and
+    language constructions. This means that our design is not suited to
+    handle such construction.
 
-Solution:
-    We need to refactor our complex construction into simpler ones.
-    We can use new functions or different constructions.
+  - Solution:  
+    We need to refactor our complex construction into simpler ones. We
+    can use new functions or different constructions.
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.5.0
+<div class="versionadded">
+
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.5.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS221.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS221.md
@@ -31,7 +31,7 @@ What nodes do we count? All except the following:
 
   - Configuration:  
     This rule is configurable with `--max-line-complexity`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_LINE_COMPLEXITY`
+    `python://wemake_python_styleguide.options.defaults.MAX_LINE_COMPLEXITY`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS221.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS221.md
@@ -3,39 +3,41 @@ code: 221
 title: 'Found line with high Jones Complexity: {0}'
 ---
 
-
 Forbid complex lines.
 
-We are using the Jones Complexity algorithm to count complexity.
-What is the Jones Complexity? It is a simple yet powerful method to count
-the number of ``ast`` nodes per line.
-If the complexity of a single line is higher than a threshold,
-then an error is raised.
+We are using the Jones Complexity algorithm to count complexity. What is
+the Jones Complexity? It is a simple yet powerful method to count the
+number of `ast` nodes per line. If the complexity of a single line is
+higher than a threshold, then an error is raised.
 
 What nodes do we count? All except the following:
 
-1. modules
-2. function and classes, since they are checked differently
-3. type annotations, since they do not increase the complexity
+1.  modules
+2.  function and classes, since they are checked differently
+3.  type annotations, since they do not increase the complexity
 
-Reasoning:
+<!-- end list -->
+
+  - Reasoning:  
     Having a complex line indicates that you somehow managed to put too
-    much logic inside a single line.
-    At some point in time, you will no longer be able to understand
-    what this line means and what it does.
+    much logic inside a single line. At some point in time, you will no
+    longer be able to understand what this line means and what it does.
 
-Solution:
+  - Solution:  
     Split a single line into several lines: by creating new variables,
-    statements or functions. Note, this might trigger new complexity issues.
-    With this technique, a single new node in a line might trigger a complex
-    refactoring process including several modules.
+    statements or functions. Note, this might trigger new complexity
+    issues. With this technique, a single new node in a line might
+    trigger a complex refactoring process including several modules.
 
-Configuration:
-    This rule is configurable with ``--max-line-complexity``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_LINE_COMPLEXITY`
+  - Configuration:  
+    This rule is configurable with `--max-line-complexity`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_LINE_COMPLEXITY`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
 
-See also:
-    https://github.com/Miserlou/JonesComplexity
+0.1.0
+
+</div>
+
+  - See also:  
+    <https://github.com/Miserlou/JonesComplexity>

--- a/docs/wemake-python-styleguide/0.15.2/WPS222.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS222.md
@@ -5,8 +5,8 @@ title: 'Found a condition with too much logic: {0}'
 
 Forbid conditions with too many logical operators.
 
-We use `wemake_python_styleguide.constants.MAX_CONDITIONS` as a default
-value.
+We use `python://wemake_python_styleguide.constants.MAX_CONDITIONS` as a
+default value.
 
   - Reasoning:  
     When reading through the complex conditions you will fail to

--- a/docs/wemake-python-styleguide/0.15.2/WPS222.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS222.md
@@ -3,23 +3,31 @@ code: 222
 title: 'Found a condition with too much logic: {0}'
 ---
 
-
 Forbid conditions with too many logical operators.
 
-We use :str:`wemake_python_styleguide.constants.MAX_CONDITIONS`
-as a default value.
+We use `wemake_python_styleguide.constants.MAX_CONDITIONS` as a default
+value.
 
-Reasoning:
-    When reading through the complex conditions you will fail
-    to understand all the possible branches. And you will end up putting
+  - Reasoning:  
+    When reading through the complex conditions you will fail to
+    understand all the possible branches. And you will end up putting
     debug breakpoint on this line just to figure out how it works.
 
-Solution:
-    We can reduce the complexity of a single ``if`` by doing two things:
-    creating new variables or creating nested ``if`` statements.
-    Both of these actions will trigger other complexity checks.
+  - Solution:  
+    We can reduce the complexity of a single `if` by doing two things:
+    creating new variables or creating nested `if` statements. Both of
+    these actions will trigger other complexity checks.
 
-We count ``and`` and ``or`` keywords as conditions.
+We count `and` and `or` keywords as conditions.
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.5.0
+<div class="versionadded">
+
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.5.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS223.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS223.md
@@ -3,22 +3,29 @@ code: 223
 title: 'Found too many `elif` branches: {0}'
 ---
 
+Forbid too many `elif` branches.
 
-Forbid too many ``elif`` branches.
+We use `wemake_python_styleguide.constants.MAX_ELIFS` as a default
+value.
 
-We use :str:`wemake_python_styleguide.constants.MAX_ELIFS`
-as a default value.
+  - Reasoning:  
+    This rule is specifically important because many `elif` branches
+    indicates a complex flow in your design: you are reimplementing
+    `switch` in python.
 
-Reasoning:
-    This rule is specifically important because many ``elif``
-    branches indicates a complex flow in your design:
-    you are reimplementing ``switch`` in python.
+  - Solution:  
+    There are different design patterns to use instead. For example, you
+    can use an interface that just calls a specific method without `if`.
+    Another option is to separate your `if` into multiple functions.
 
-Solution:
-    There are different design patterns to use instead.
-    For example, you can use an interface that
-    just calls a specific method without ``if``.
-    Another option is to separate your ``if`` into multiple functions.
+<div class="versionadded">
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.5.0
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.5.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS223.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS223.md
@@ -5,8 +5,8 @@ title: 'Found too many `elif` branches: {0}'
 
 Forbid too many `elif` branches.
 
-We use `wemake_python_styleguide.constants.MAX_ELIFS` as a default
-value.
+We use `python://wemake_python_styleguide.constants.MAX_ELIFS` as a
+default value.
 
   - Reasoning:  
     This rule is specifically important because many `elif` branches

--- a/docs/wemake-python-styleguide/0.15.2/WPS224.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS224.md
@@ -3,19 +3,18 @@ code: 224
 title: Found a comprehension with too many `for` statements
 ---
 
+Forbid too many `for` statements within a comprehension.
 
-Forbid too many ``for`` statements within a comprehension.
+  - Reasoning:  
+    When reading through the complex comprehension you will fail to
+    understand it.
 
-Reasoning:
-    When reading through the complex comprehension you will fail
-    to understand it.
-
-Solution:
+  - Solution:  
     We can reduce the complexity of the comprehension by reducing the
-    amount of ``for`` statements. Refactor your code to use several
-    ``for`` loops, comprehensions, or different functions.
+    amount of `for` statements. Refactor your code to use several `for`
+    loops, comprehensions, or different functions.
 
-Example::
+Example:
 
     # Wrong:
     ast_nodes = [
@@ -25,4 +24,8 @@ Example::
         for _ in range(10)
     ]
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS225.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS225.md
@@ -3,21 +3,24 @@ code: 225
 title: 'Found too many `except` cases: {0}'
 ---
 
+Forbid too many `except` cases in a single `try` clause.
 
-Forbid too many ``except`` cases in a single ``try`` clause.
+We use `wemake_python_styleguide.constants.MAX_EXCEPT_CASES` as a
+default value.
 
-We use :str:`wemake_python_styleguide.constants.MAX_EXCEPT_CASES`
-as a default value.
+  - Reasoning:  
+    Handling too many exceptions in a single place is a good indicator
+    of a bad design since one controlling structure will become too
+    complex. Also, you will need to test a lot of logic paths in your
+    application.
 
-Reasoning:
-    Handling too many exceptions in a single place
-    is a good indicator of a bad design
-    since one controlling structure will become too complex.
-    Also, you will need to test a lot of logic paths in your application.
+  - Solution:  
+    We can reduce the complexity of this case by splitting it into
+    multiple `try` cases, functions or using a decorator to handle
+    different exceptions.
 
-Solution:
-    We can reduce the complexity of this case by splitting it into multiple
-    ``try`` cases, functions or using a decorator
-    to handle different exceptions.
+<div class="versionadded">
 
-.. versionadded:: 0.7.0
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS225.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS225.md
@@ -5,8 +5,8 @@ title: 'Found too many `except` cases: {0}'
 
 Forbid too many `except` cases in a single `try` clause.
 
-We use `wemake_python_styleguide.constants.MAX_EXCEPT_CASES` as a
-default value.
+We use `python://wemake_python_styleguide.constants.MAX_EXCEPT_CASES` as
+a default value.
 
   - Reasoning:  
     Handling too many exceptions in a single place is a good indicator

--- a/docs/wemake-python-styleguide/0.15.2/WPS226.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS226.md
@@ -19,7 +19,7 @@ variables, arguments, return values, and class attributes.
 
   - Configuration:  
     This rule is configurable with `--max-string-usages`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_STRING_USAGES`
+    `python://wemake_python_styleguide.options.defaults.MAX_STRING_USAGES`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS226.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS226.md
@@ -3,24 +3,26 @@ code: 226
 title: 'Found string constant over-use: {0}'
 ---
 
-
 Forbid the overuse of string constants.
 
 We allow to use strings without any restrictions as annotations for
 variables, arguments, return values, and class attributes.
 
-Reasoning:
-    When some string is used more than several time in your code,
-    it probably means that this string is a meaningful constant
-    and should be treated like one.
+  - Reasoning:  
+    When some string is used more than several time in your code, it
+    probably means that this string is a meaningful constant and should
+    be treated like one.
 
-Solution:
-    Deduplicate you string usages
-    by defining new functions or constants.
+  - Solution:  
+    Deduplicate you string usages by defining new functions or
+    constants.
 
-Configuration:
-    This rule is configurable with ``--max-string-usages``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_STRING_USAGES`
+  - Configuration:  
+    This rule is configurable with `--max-string-usages`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_STRING_USAGES`
 
-.. versionadded:: 0.10.0
+<div class="versionadded">
+
+0.10.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS227.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS227.md
@@ -3,14 +3,17 @@ code: 227
 title: 'Found too long yield tuple: {0}'
 ---
 
-
 Forbid yielding tuples that are too long.
 
-Reasoning:
-    Long yield tuples complicate generator usage.
-    This rule helps to reduce complication.
+  - Reasoning:  
+    Long yield tuples complicate generator usage. This rule helps to
+    reduce complication.
 
-Solution:
+  - Solution:  
     Use lists of similar type or wrapper objects.
 
-.. versionadded:: 0.10.0
+<div class="versionadded">
+
+0.10.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS228.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS228.md
@@ -3,15 +3,18 @@ code: 228
 title: Found too long compare
 ---
 
-
 Forbid compare expressions that are too long.
 
-Reasoning:
-    Compare expressions that are too long indicate
-    that there's something wrong going on in the code.
-    Compares should not be longer than 3 or 4 items.
+  - Reasoning:  
+    Compare expressions that are too long indicate that there's
+    something wrong going on in the code. Compares should not be longer
+    than 3 or 4 items.
 
-Solution:
+  - Solution:  
     Use several conditions, separate variables, or functions.
 
-.. versionadded:: 0.10.0
+<div class="versionadded">
+
+0.10.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS229.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS229.md
@@ -17,7 +17,7 @@ Forbid `try` blocks with bodies that are too long.
 
   - Configuration:  
     This rule is configurable with `--max-try-body-length`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_TRY_BODY_LENGTH`
+    `python://wemake_python_styleguide.options.defaults.MAX_TRY_BODY_LENGTH`
 
   - See also:  
     <https://adamj.eu/tech/2019/10/02/limit-your-try-clauses-in-python/>

--- a/docs/wemake-python-styleguide/0.15.2/WPS229.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS229.md
@@ -3,26 +3,27 @@ code: 229
 title: 'Found too long ``try`` body length: {0}'
 ---
 
+Forbid `try` blocks with bodies that are too long.
 
-Forbid ``try`` blocks with bodies that are too long.
+  - Reasoning:  
+    Having too many statements inside your `try` block can lead to
+    situations when a statement raises an exception and you are not
+    aware of it since it is not expected.
 
-Reasoning:
-    Having too many statements inside your ``try`` block
-    can lead to situations when a statement
-    raises an exception and you are not aware of it
-    since it is not expected.
+  - Solution:  
+    Move things out of the `try` block or create new functions. The
+    fewer lines you have in your `try` block - the safer you are from
+    accidental errors.
 
-Solution:
-    Move things out of the ``try`` block or create new functions.
-    The fewer lines you have in your ``try`` block - the safer
-    you are from accidental errors.
+  - Configuration:  
+    This rule is configurable with `--max-try-body-length`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_TRY_BODY_LENGTH`
 
-Configuration:
-    This rule is configurable with ``--max-try-body-length``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_TRY_BODY_LENGTH`
+  - See also:  
+    <https://adamj.eu/tech/2019/10/02/limit-your-try-clauses-in-python/>
 
-See also:
-    https://adamj.eu/tech/2019/10/02/limit-your-try-clauses-in-python/
+<div class="versionadded">
 
-.. versionadded:: 0.12.0
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS230.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS230.md
@@ -3,34 +3,32 @@ code: 230
 title: 'Found too many public instance attributes: {0}'
 ---
 
-
 Forbid instances with too many public attributes.
 
-We only check static definitions in a form of ``self.public = ...``.
-We do not count parent attributes.
-We do not count properties.
-We do not count annotations.
-We do not count class attributes.
-We do not count duplicates.
+We only check static definitions in a form of `self.public = ...`. We do
+not count parent attributes. We do not count properties. We do not count
+annotations. We do not count class attributes. We do not count
+duplicates.
 
-Reasoning:
-    Having too many public instance attributes means
-    that your class is too complex in terms of coupling.
-    Other classes and functions will rely on these concrete fields
-    instead of better abstraction layers.
+  - Reasoning:  
+    Having too many public instance attributes means that your class is
+    too complex in terms of coupling. Other classes and functions will
+    rely on these concrete fields instead of better abstraction layers.
 
-Solution:
-    Make some attributes protected.
-    Split this class into several.
-    If the class is a Data Transfer Object,
-    then use ``@dataclass`` decorator.
+  - Solution:  
+    Make some attributes protected. Split this class into several. If
+    the class is a Data Transfer Object, then use `@dataclass`
+    decorator.
 
-Configuration:
-    This rule is configurable with ``--max-attributes``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_ATTRIBUTES`
+  - Configuration:  
+    This rule is configurable with `--max-attributes`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_ATTRIBUTES`
 
-See also:
-    https://en.wikipedia.org/wiki/Coupling_(computer_programming)
+  - See also:  
+    <https://en.wikipedia.org/wiki/Coupling_(computer_programming)>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS230.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS230.md
@@ -22,7 +22,7 @@ duplicates.
 
   - Configuration:  
     This rule is configurable with `--max-attributes`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_ATTRIBUTES`
+    `python://wemake_python_styleguide.options.defaults.MAX_ATTRIBUTES`
 
   - See also:  
     <https://en.wikipedia.org/wiki/Coupling_(computer_programming)>

--- a/docs/wemake-python-styleguide/0.15.2/WPS231.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS231.md
@@ -3,27 +3,29 @@ code: 231
 title: 'Found function with too much cognitive complexity: {0}'
 ---
 
-
 Forbid functions with too much cognitive complexity.
 
-Reasoning:
-    People are not great at reading and interpreting code in their heads.
-    That's why code with a lot of nested loops,
-    conditions, exceptions handlers,
-    and context managers is hard to read and understand.
+  - Reasoning:  
+    People are not great at reading and interpreting code in their
+    heads. That's why code with a lot of nested loops, conditions,
+    exceptions handlers, and context managers is hard to read and
+    understand.
 
-Solution:
-    Rewrite your code to be simpler.
-    Use flat structures and conditions, remove nested loops.
+  - Solution:  
+    Rewrite your code to be simpler. Use flat structures and conditions,
+    remove nested loops.
 
-Configuration:
-    This rule is configurable with ``--max-cognitive-score``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_COGNITIVE_SCORE`
+  - Configuration:  
+    This rule is configurable with `--max-cognitive-score`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_COGNITIVE_SCORE`
 
-See also:
-    https://en.wikipedia.org/wiki/Cognitive_complexity
-    https://pypi.org/project/cognitive-complexity/
-    https://github.com/Melevir/flake8-cognitive-complexity
+  - See also:  
+    <https://en.wikipedia.org/wiki/Cognitive_complexity>
+    <https://pypi.org/project/cognitive-complexity/>
+    <https://github.com/Melevir/flake8-cognitive-complexity>
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS231.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS231.md
@@ -17,7 +17,7 @@ Forbid functions with too much cognitive complexity.
 
   - Configuration:  
     This rule is configurable with `--max-cognitive-score`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_COGNITIVE_SCORE`
+    `python://wemake_python_styleguide.options.defaults.MAX_COGNITIVE_SCORE`
 
   - See also:  
     <https://en.wikipedia.org/wiki/Cognitive_complexity>

--- a/docs/wemake-python-styleguide/0.15.2/WPS232.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS232.md
@@ -3,23 +3,24 @@ code: 232
 title: 'Found module cognitive complexity that is too high: {0}'
 ---
 
-
 Forbid modules with average cognitive complexity that is too high.
 
-Reasoning:
+  - Reasoning:  
     Modules with lots of functions might hide cognitive complexity
     inside many small and relatively simple functions.
 
-Solution:
-    Rewrite your code to be simpler
-    or use several modules.
+  - Solution:  
+    Rewrite your code to be simpler or use several modules.
 
-Configuration:
-    This rule is configurable with ``--max-cognitive-average``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_COGNITIVE_AVERAGE`
+  - Configuration:  
+    This rule is configurable with `--max-cognitive-average`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_COGNITIVE_AVERAGE`
 
-See also:
-    https://en.wikipedia.org/wiki/Cognitive_complexity
+  - See also:  
+    <https://en.wikipedia.org/wiki/Cognitive_complexity>
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS232.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS232.md
@@ -14,7 +14,7 @@ Forbid modules with average cognitive complexity that is too high.
 
   - Configuration:  
     This rule is configurable with `--max-cognitive-average`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_COGNITIVE_AVERAGE`
+    `python://wemake_python_styleguide.options.defaults.MAX_COGNITIVE_AVERAGE`
 
   - See also:  
     <https://en.wikipedia.org/wiki/Cognitive_complexity>

--- a/docs/wemake-python-styleguide/0.15.2/WPS233.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS233.md
@@ -3,20 +3,22 @@ code: 233
 title: 'Found call chain that is too long: {0}'
 ---
 
-
 Forbid call chains that are too long.
 
-Reasoning:
-    Call chains that are too long are overcomplicated and
-    indicators of bad API design.
+  - Reasoning:  
+    Call chains that are too long are overcomplicated and indicators of
+    bad API design.
 
-Solution:
-    Split the expression into variables, functions or classes.
-    Refactor the API to allow higher-level access to functions.
+  - Solution:  
+    Split the expression into variables, functions or classes. Refactor
+    the API to allow higher-level access to functions.
 
-Configuration:
-    This rule is configurable with ``--max-call-level``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_CALL_LEVEL`
+  - Configuration:  
+    This rule is configurable with `--max-call-level`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_CALL_LEVEL`
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS233.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS233.md
@@ -15,7 +15,7 @@ Forbid call chains that are too long.
 
   - Configuration:  
     This rule is configurable with `--max-call-level`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_CALL_LEVEL`
+    `python://wemake_python_styleguide.options.defaults.MAX_CALL_LEVEL`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS234.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS234.md
@@ -3,27 +3,30 @@ code: 234
 title: 'Found overly complex annotation: {0}'
 ---
 
-
 Forbid overly complex annotations.
 
-Annotation complexity is maximum annotation nesting level.
-Example: ``List[int]`` has complexity of 2
-and ``Tuple[List[Optional[str]], int]`` has complexity of 4.
+Annotation complexity is maximum annotation nesting level. Example:
+`List[int]` has complexity of 2 and `Tuple[List[Optional[str]], int]`
+has complexity of 4.
 
-Reasoning:
-    Overly complex annotations make your types unreadable.
-    And make developers afraid of types.
+  - Reasoning:  
+    Overly complex annotations make your types unreadable. And make
+    developers afraid of types.
 
-Solution:
-    Create type aliases. And use them a lot!
+  - Solution:  
+    Create type aliases. And use them a lot\!
 
-Configuration:
-    This rule is configurable with ``--max-annotation-complexity``.
+  - Configuration:  
+    This rule is configurable with `--max-annotation-complexity`.
     Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_ANN_COMPLEXITY`
+    `wemake_python_styleguide.options.defaults.MAX_ANN_COMPLEXITY`
 
-See also:
-    https://mypy.readthedocs.io/en/stable/kinds_of_types.html#type-aliases
-    https://github.com/best-doctor/flake8-annotations-complexity
+  - See also:  
+    <https://mypy.readthedocs.io/en/stable/kinds_of_types.html#type-aliases>
+    <https://github.com/best-doctor/flake8-annotations-complexity>
 
-.. versionadded:: 0.14.0
+<div class="versionadded">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS234.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS234.md
@@ -19,7 +19,7 @@ has complexity of 4.
   - Configuration:  
     This rule is configurable with `--max-annotation-complexity`.
     Default:
-    `wemake_python_styleguide.options.defaults.MAX_ANN_COMPLEXITY`
+    `python://wemake_python_styleguide.options.defaults.MAX_ANN_COMPLEXITY`
 
   - See also:  
     <https://mypy.readthedocs.io/en/stable/kinds_of_types.html#type-aliases>

--- a/docs/wemake-python-styleguide/0.15.2/WPS235.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS235.md
@@ -24,7 +24,7 @@ Example:
 
   - Configuration:  
     This rule is configurable with `--max-import-from-members`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_IMPORT_FROM_MEMBERS`
+    `python://wemake_python_styleguide.options.defaults.MAX_IMPORT_FROM_MEMBERS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS235.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS235.md
@@ -3,29 +3,31 @@ code: 235
 title: 'Found too many imported names from a module: {0}'
 ---
 
+Forbid `from ... import ...` with too many imported names.
 
-Forbid ``from ... import ...`` with too many imported names.
+  - Reasoning:  
+    Importing too many names from one import is an easy way to cause the
+    violation `WPS203` - too many imported names.
 
-Reasoning:
-    Importing too many names from one import is an easy way to cause
-    the violation ``WPS203`` - too many imported names.
-
-Solution:
+  - Solution:  
     Refactor the imports to import a common namespace. Something like
-    ``from package import module`` and then
-    use it like ``module.function()``.
+    `from package import module` and then use it like
+    `module.function()`.
 
-Example::
+Example:
 
     # Correct:
     import module  # 1 imported name
-
+    
     # Wrong:
     from module import func1, func2, ..., funcN  # N imported names
 
-Configuration:
-    This rule is configurable with ``--max-import-from-members``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_IMPORT_FROM_MEMBERS`
+  - Configuration:  
+    This rule is configurable with `--max-import-from-members`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_IMPORT_FROM_MEMBERS`
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS236.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS236.md
@@ -22,7 +22,7 @@ Example:
 
   - Configuration:  
     This rule is configurable with `--max-tuple-unpack-length`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_TUPLE_UNPACK_LENGTH`
+    `python://wemake_python_styleguide.options.defaults.MAX_TUPLE_UNPACK_LENGTH`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS236.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS236.md
@@ -3,27 +3,29 @@ code: 236
 title: 'Found too many variables used to unpack a tuple: {0}'
 ---
 
-
 Forbid using too many variables to unpack a tuple.
 
-Reasoning:
+  - Reasoning:  
     The order and meaning are hard to remember.
 
-Solution:
+  - Solution:  
     If you have more than 2 values in a tuple, consider using
-    ``typing.NamedTuple`` or a dataclass instead.
+    `typing.NamedTuple` or a dataclass instead.
 
-Example::
+Example:
 
     # Correct:
     result = foo()
-
+    
     # Wrong:
     a, b, c, d, e = foo()
 
-Configuration:
-    This rule is configurable with ``--max-tuple-unpack-length``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_TUPLE_UNPACK_LENGTH`
+  - Configuration:  
+    This rule is configurable with `--max-tuple-unpack-length`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_TUPLE_UNPACK_LENGTH`
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS237.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS237.md
@@ -3,35 +3,38 @@ code: 237
 title: Found a too complex `f` string
 ---
 
+Forbids `f` strings that are too complex.
 
-Forbids ``f`` strings that are too complex.
+A complex format string is defined as use of any formatted value that is
+not:
 
-A complex format string is defined as use of any formatted value
-that is not:
+  - the value of a variable
+  - the value of a collection through lookup with a variable, number, or
+    string as the key
+  - the return value of a procedure call without arguments
 
-- the value of a variable
-- the value of a collection through lookup with a variable, number, or
-  string as the key
-- the return value of a procedure call without arguments
+Related to `~FormattedStringViolation`.
 
-Related to :class:`~FormattedStringViolation`.
+  - Reasoning:  
+    Complex `f` strings are often difficult to understand, making the
+    code less readable. Generally we don't allow `f` strings but this
+    violation exists in case the user decides to ignore the general
+    violation.
 
-Reasoning:
-    Complex ``f`` strings are often difficult to understand,
-    making the code less readable. Generally we don't allow
-    ``f`` strings but this violation exists in case the user
-    decides to ignore the general violation.
+  - Solution:  
+    Use `.format()` or assign complex expressions to variables before
+    formatting.
 
-Solution:
-    Use ``.format()`` or assign complex expressions to variables
-    before formatting.
-
-Example::
+Example:
 
     # Correct:
     f'smth {user.get_full_name()}'
-
+    
     # Wrong:
     f'{reverse("url-name")}?{"&".join("user="+uid for uid in user_ids)}'
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS238.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS238.md
@@ -3,22 +3,23 @@ code: 238
 title: 'Found too many raises in a function: {0}'
 ---
 
+Forbids too many `raise` statements in a function.
 
-Forbids too many ``raise`` statements in a function.
+  - Reasoning:  
+    Too many `raise` statements in a function make the code untraceable
+    and overcomplicated.
 
-Reasoning:
-    Too many ``raise`` statements in a function make the code
-    untraceable and overcomplicated.
+  - Solution:  
+    Split the function into smaller functions, such that each of them
+    can raise less errors. Create more standard errors, or use
+    alternative ways to raise them.
 
-Solution:
-    Split the function into smaller functions, such that
-    each of them can raise less errors.
-    Create more standard errors, or use alternative ways to
-    raise them.
+  - Configuration:  
+    This rule is configurable with `--max-raises`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_RAISES`
 
-Configuration:
-    This rule is configurable with ``--max-raises``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_RAISES`
+<div class="versionadded">
 
-.. versionadded:: 0.15.0
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS238.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS238.md
@@ -16,7 +16,7 @@ Forbids too many `raise` statements in a function.
 
   - Configuration:  
     This rule is configurable with `--max-raises`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_RAISES`
+    `python://wemake_python_styleguide.options.defaults.MAX_RAISES`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS300.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS300.md
@@ -3,23 +3,26 @@ code: 300
 title: Found local folder import
 ---
 
-
 Forbid imports relative to the current folder.
 
-Reasoning:
-    We should pick one style and stick to it.
-    We have decided to use the explicit one.
+  - Reasoning:  
+    We should pick one style and stick to it. We have decided to use the
+    explicit one.
 
-Solution:
+  - Solution:  
     Refactor your imports to use the absolute path.
 
-Example::
+Example:
 
     # Correct:
     from my_package.version import get_version
-
+    
     # Wrong:
     from .version import get_version
     from ..drivers import MySQLDriver
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS301.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS301.md
@@ -3,23 +3,25 @@ code: 301
 title: 'Found dotted raw import: {0}'
 ---
 
+Forbid imports like `import os.path`.
 
-Forbid imports like ``import os.path``.
+  - Reasoning:  
+    There are too many ways to import something. We should pick one
+    style and stick to it. We have decided to use the readable one.
 
-Reasoning:
-    There are too many ways to import something.
-    We should pick one style and stick to it.
-    We have decided to use the readable one.
-
-Solution:
+  - Solution:  
     Refactor your import statement.
 
-Example::
+Example:
 
     # Correct:
     from os import path
-
+    
     # Wrong:
     import os.path
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS302.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS302.md
@@ -3,23 +3,26 @@ code: 302
 title: 'Found unicode string prefix: {0}'
 ---
 
+Forbid `u` string prefix.
 
-Forbid ``u`` string prefix.
+  - Reasoning:  
+    We haven't needed this prefix since `python2`, but it is still
+    possible to find it in a codebase.
 
-Reasoning:
-    We haven't needed this prefix since ``python2``,
-    but it is still possible to find it in a codebase.
-
-Solution:
+  - Solution:  
     Remove this prefix.
 
-Example::
+Example:
 
     # Correct:
     nickname = 'sobolevn'
     file_contents = b'aabbcc'
-
+    
     # Wrong:
     nickname = u'sobolevn'
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS303.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS303.md
@@ -3,29 +3,31 @@ code: 303
 title: 'Found underscored number: {0}'
 ---
 
+Forbid underscores (`_`) in numbers.
 
-Forbid underscores (``_``) in numbers.
+  - Reasoning:  
+    It is possible to write `1000` in three different ways: `1_000`,
+    `10_00`, and `100_0`. And it would be still the same number. Count
+    how many ways there are to write bigger numbers. Currently, it all
+    depends on the cultural habits of the author. We enforce a single
+    way to write numbers: without the underscore.
 
-Reasoning:
-    It is possible to write ``1000`` in three different ways:
-    ``1_000``, ``10_00``, and ``100_0``.
-    And it would be still the same number.
-    Count how many ways there are to write bigger numbers.
-    Currently, it all depends on the cultural habits of the author.
-    We enforce a single way to write numbers: without the underscore.
+  - Solution:  
+    Numbers should be written as numbers: `1000`. If you have a very big
+    number with a lot of zeros, use multiplication.
 
-Solution:
-    Numbers should be written as numbers: ``1000``.
-    If you have a very big number with a lot of zeros, use multiplication.
-
-Example::
+Example:
 
     # Correct:
     phone = 88313443
     million = 1000000
-
+    
     # Wrong:
     phone = 8_83_134_43
     million = 100_00_00
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS304.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS304.md
@@ -3,26 +3,28 @@ code: 304
 title: 'Found partial float: {0}'
 ---
 
+Forbid partial floats like `.05` or `23.`.
 
-Forbid partial floats like ``.05`` or ``23.``.
+  - Reasoning:  
+    Partial numbers are hard to read and they can be confused with other
+    numbers. For example, it is really easy to confuse `0.5` and `.05`
+    when reading through the source code.
 
-Reasoning:
-    Partial numbers are hard to read and they can be confused with
-    other numbers. For example, it is really
-    easy to confuse ``0.5`` and ``.05`` when reading
-    through the source code.
-
-Solution:
+  - Solution:  
     Use full versions with leading and trailing zeros.
 
-Example::
+Example:
 
     # Correct:
     half = 0.5
     ten_float = 10.0
-
+    
     # Wrong:
     half = .5
     ten_float = 10.
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS305.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS305.md
@@ -3,32 +3,33 @@ code: 305
 title: Found `f` string
 ---
 
+Forbid `f` strings.
 
-Forbid ``f`` strings.
+  - Reasoning:  
+    `f` strings implicitly rely on the context around them. Imagine that
+    you have a string that breaks when you move it two lines above.
+    That's not how a string should behave. Also, they promote a bad
+    practice: putting your logic inside the template. Moreover, they do
+    two things at once: declare a template and format it in a single
+    action.
 
-Reasoning:
-    ``f`` strings implicitly rely on the context around them.
-    Imagine that you have a string that breaks
-    when you move it two lines above.
-    That's not how a string should behave.
-    Also, they promote a bad practice:
-    putting your logic inside the template.
-    Moreover, they do two things at once:
-    declare a template and format it in a single action.
+  - Solution:  
+    Use `.format()` with indexed params instead.
 
-Solution:
-    Use ``.format()`` with indexed params instead.
+  - See also:  
+    <https://github.com/xZise/flake8-string-format>
 
-See also:
-    https://github.com/xZise/flake8-string-format
-
-Example::
+Example:
 
     # Wrong:
     f'Result is: {2 + 2}'
-
+    
     # Correct:
     'Result is: {0}'.format(2 + 2)
     'Hey {user}! How are you?'.format(user='sobolevn')
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS306.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS306.md
@@ -3,30 +3,33 @@ code: 306
 title: 'Found class without a base class: {0}'
 ---
 
-
 Forbid writing classes without base classes.
 
-Please, note that this rule has nothing to do with ``python2``.
-We care only about consistency here.
+Please, note that this rule has nothing to do with `python2`. We care
+only about consistency here.
 
-Reasoning:
-    We just need to decide how to do it.
-    We need a single and unified rule about base classes.
-    We have decided to stick to the explicit base class notation.
-    Why? Because it is consistent with other use-cases.
-    When we have a base class ``A``, we write ``class MyClass(A):``.
-    When we have no base class, we have an implicit ``object`` base class.
-    So, we still use the same syntax: ``class MyClass(object):``.
+  - Reasoning:  
+    We just need to decide how to do it. We need a single and unified
+    rule about base classes. We have decided to stick to the explicit
+    base class notation. Why? Because it is consistent with other
+    use-cases. When we have a base class `A`, we write `class
+    MyClass(A):`. When we have no base class, we have an implicit
+    `object` base class. So, we still use the same syntax: `class
+    MyClass(object):`.
 
-Solution:
+  - Solution:  
     Add a base class.
 
-Example::
+Example:
 
     # Correct:
     class Some(object): ...
-
+    
     # Wrong:
     class Some: ...
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS307.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS307.md
@@ -3,24 +3,27 @@ code: 307
 title: Found list comprehension with multiple `if`s
 ---
 
+Forbid multiple `if` statements inside list comprehensions.
 
-Forbid multiple ``if`` statements inside list comprehensions.
+  - Reasoning:  
+    It is very hard to read multiple `if` statements inside a list
+    comprehension. Since it is even hard to tell all of them should pass
+    or fail.
 
-Reasoning:
-    It is very hard to read multiple ``if`` statements inside
-    a list comprehension. Since it is even hard to tell all of them
-    should pass or fail.
+  - Solution:  
+    Use a single `if` statement inside list comprehensions. Use
+    `filter()` if you have complicated logic.
 
-Solution:
-    Use a single ``if`` statement inside list comprehensions.
-    Use ``filter()`` if you have complicated logic.
-
-Example::
+Example:
 
     # Wrong:
     nodes = [node for node in html if node != 'b' if node != 'i']
-
+    
     # Correct:
     nodes = [node for node in html if node not in ('b', 'i')]
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS308.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS308.md
@@ -3,26 +3,29 @@ code: 308
 title: Found constant comparison
 ---
 
-
 Forbid comparing between two literals.
 
-Reasoning:
+  - Reasoning:  
     When two constants are compared it is typically an indication of a
     mistake, since the Boolean value of the comparison, will always be
     the same.
 
-Solution:
+  - Solution:  
     Remove the constant comparison and any associated dead code.
 
-Example::
+Example:
 
     # Wrong:
     if 60 * 60 < 1000:
         do_something()
     else:
         do_something_else()
-
+    
     # Correct:
     do_something_else()
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS309.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS309.md
@@ -3,24 +3,26 @@ code: 309
 title: Found reversed compare order
 ---
 
-
 Forbid comparisons where the argument doesn't come first.
 
-Reasoning:
-    It is hard to read the code when
-    you have to shuffle the ordering of the arguments all the time.
-    Bring consistency to the comparison!
+  - Reasoning:  
+    It is hard to read the code when you have to shuffle the ordering of
+    the arguments all the time. Bring consistency to the comparison\!
 
-Solution:
+  - Solution:  
     Refactor your comparison expression, place the argument first.
 
-Example::
+Example:
 
     # Correct:
     if some_x > 3:
     if 3 < some_x < 10:
-
+    
     # Wrong:
     if 3 < some_x:
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS310.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS310.md
@@ -3,32 +3,35 @@ code: 310
 title: 'Found bad number suffix: {0}'
 ---
 
+Forbid uppercase `X`, `O`, `B`, and `E` in numbers.
 
-Forbid uppercase ``X``, ``O``, ``B``, and ``E`` in numbers.
+  - Reasoning:  
+    Octal, hex, binary and scientific notation suffixes could be written
+    in two possible notations: lowercase and uppercase which brings
+    confusion and decreases code consistency and readability. We enforce
+    a single way to write numbers with suffixes: suffix with lowercase
+    chars.
 
-Reasoning:
-    Octal, hex, binary and scientific notation suffixes could
-    be written in two possible notations: lowercase and uppercase
-    which brings confusion and decreases code consistency and readability.
-    We enforce a single way to write numbers with suffixes:
-    suffix with lowercase chars.
-
-Solution:
+  - Solution:  
     Octal, hex, binary and scientific notation suffixes in numbers
     should be written in lowercase.
 
-Example::
+Example:
 
     # Correct:
     hex_number = 0xFF
     octal_number = 0o11
     binary_number = 0b1001
     number_with_scientific_notation = 1.5e+10
-
+    
     # Wrong:
     hex_number = 0XFF
     octal_number = 0O11
     binary_number = 0B1001
     number_with_scientific_notation = 1.5E+10
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS311.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS311.md
@@ -3,25 +3,33 @@ code: 311
 title: Found multiple `in` compares
 ---
 
+Forbid comparisons with multiple `in` checks.
 
-Forbid comparisons with multiple ``in`` checks.
+  - Reasoning:  
+    Using multiple `in` checks is unreadable.
 
-Reasoning:
-    Using multiple ``in`` checks is unreadable.
+  - Solution:  
+    Refactor your comparison expression to use several `and` conditions
+    or separate `if` statements in cases where it is appropriate.
 
-Solution:
-    Refactor your comparison expression to use several ``and`` conditions
-    or separate ``if`` statements in cases where it is appropriate.
-
-Example::
+Example:
 
     # Correct:
     if item in bucket and bucket in master_list_of_buckets:
     if x_coord not in line and line not in square:
-
+    
     # Wrong:
     if item in bucket in master_list_of_buckets:
     if x_cord not in line not in square:
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.10.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.10.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS312.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS312.md
@@ -3,26 +3,29 @@ code: 312
 title: Found comparison of a variable to itself
 ---
 
-
 Forbid comparisons of a variable to itself.
 
-Reasoning:
+  - Reasoning:  
     When a variable is compared to itself, it is typically an indication
-    of a mistake since the Boolean value of the comparison will always be
-    the same.
+    of a mistake since the Boolean value of the comparison will always
+    be the same.
 
-Solution:
+  - Solution:  
     Remove the comparison and any associated dead code.
 
-Example::
+Example:
 
     # Correct:
     do_something()
-
+    
     # Wrong:
     if a < a:
         do_something()
     else:
         do_something_else()
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS313.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS313.md
@@ -3,17 +3,16 @@ code: 313
 title: Found parenthesis immediately after a keyword
 ---
 
-
 Enforce separation of parenthesis from keywords with spaces.
 
-Reasoning:
-    Some people use ``return`` and ``yield`` keywords as functions.
-    The same happened to good old ``print`` in Python2.
+  - Reasoning:  
+    Some people use `return` and `yield` keywords as functions. The same
+    happened to good old `print` in Python2.
 
-Solution:
+  - Solution:  
     Insert space symbol between the keyword and opening parenthesis.
 
-Example::
+Example:
 
     # Wrong:
     def func():
@@ -21,11 +20,15 @@ Example::
         b = 2
         del(a, b)
         yield(1, 2, 3)
-
+    
     # Correct:
     def func():
         a = 1
         del (a, b)
         yield (1, 2, 3)
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS314.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS314.md
@@ -3,23 +3,26 @@ code: 314
 title: Found conditional that always evaluates the same
 ---
 
+Forbid using `if` statements that use invalid conditionals.
 
-Forbid using ``if`` statements that use invalid conditionals.
+  - Reasoning:  
+    When invalid conditional arguments are used it is typically an
+    indication of a mistake, since the value of the conditional result
+    will always be the same.
 
-Reasoning:
-    When invalid conditional arguments are used
-    it is typically an indication of a mistake, since
-    the value of the conditional result will always be the same.
-
-Solution:
+  - Solution:  
     Remove the conditional and any associated dead code.
 
-Example::
+Example:
 
     # Correct:
     if value is True: ...
-
+    
     # Wrong:
     if True: ...
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
+
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS315.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS315.md
@@ -3,25 +3,27 @@ code: 315
 title: Found extra `object` in parent classes list
 ---
 
+Forbid extra `object` in parent classes list.
 
-Forbid extra ``object`` in parent classes list.
-
-Reasoning:
-    We should allow object only when
-    we explicitly use it as a single parent class.
-    When there is another class or there are multiple
+  - Reasoning:  
+    We should allow object only when we explicitly use it as a single
+    parent class. When there is another class or there are multiple
     parents - we should not allow it for the consistency reasons.
 
-Solution:
-    Remove extra ``object`` parent class from the list.
+  - Solution:  
+    Remove extra `object` parent class from the list.
 
-Example::
+Example:
 
-   # Correct:
-   class SomeClassName(object): ...
-   class SomeClassName(FirstParentClass, SecondParentClass): ...
+    # Correct:
+    class SomeClassName(object): ...
+    class SomeClassName(FirstParentClass, SecondParentClass): ...
+    
+    # Wrong:
+    class SomeClassName(FirstParentClass, SecondParentClass, object): ...
 
-   # Wrong:
-   class SomeClassName(FirstParentClass, SecondParentClass, object): ...
+<div class="versionadded">
 
-.. versionadded:: 0.3.0
+0.3.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS316.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS316.md
@@ -3,28 +3,31 @@ code: 316
 title: Found context manager with too many assignments
 ---
 
-
 Forbid multiple assignment targets for context managers.
 
-Reasoning:
-    It is hard to distinguish whether ``as`` should unpack into
-    a tuple or if we are just using two context managers.
+  - Reasoning:  
+    It is hard to distinguish whether `as` should unpack into a tuple or
+    if we are just using two context managers.
 
-Solution:
+  - Solution:  
     Use several context managers or explicit brackets.
 
-Example::
+Example:
 
     # Correct:
     with open('') as first:
         with second:
             ...
-
+    
     with some_context as (first, second):
         ...
-
+    
     # Wrong:
     with open('') as first, second:
         ...
 
-.. versionadded:: 0.6.0
+<div class="versionadded">
+
+0.6.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS317.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS317.md
@@ -3,43 +3,41 @@ code: 317
 title: Found incorrect multi-line parameters
 ---
 
-
 Forbid incorrect indentation for parameters.
 
-Reasoning:
+  - Reasoning:  
     It is really easy to spoil your perfect, readable code with
-    incorrect multi-line parameters indentation.
-    Since it is really easy to style them in any of 100 possible ways.
-    We enforce a strict rule about how it is possible to write these
-    multi-line parameters.
+    incorrect multi-line parameters indentation. Since it is really easy
+    to style them in any of 100 possible ways. We enforce a strict rule
+    about how it is possible to write these multi-line parameters.
 
-Solution:
+  - Solution:  
     Use consistent multi-line parameters indentation.
 
-Example::
+Example:
 
     # Correct:
     def my_function(arg1, arg2, arg3) -> None:
         return None
-
+    
     print(1, 2, 3, 4, 5, 6)
-
+    
     def my_function(
         arg1, arg2, arg3,
     ) -> None:
         return None
-
+    
     print(
         1, 2, 3, 4, 5, 6,
     )
-
+    
     def my_function(
         arg1,
         arg2,
         arg3,
     ) -> None:
         return None
-
+    
     print(
         first_variable,
         2,
@@ -48,25 +46,28 @@ Example::
         5,
         last_item,
     )
-
+    
     # Special case:
-
+    
     print('some text', 'description', [
         first_variable,
         second_variable,
         third_variable,
         last_item,
     ], end='')
-
+    
     # Correct complex case:
-
+    
     @pytest.mark.parametrize(('boolean_arg', 'string_arg'), [
          (True, "string"),
          (False, "another string"),
     ])
 
-Everything else is considered a violation.
-This rule checks: lists, sets, tuples, dicts, calls,
-functions, methods, and classes.
+Everything else is considered a violation. This rule checks: lists,
+sets, tuples, dicts, calls, functions, methods, and classes.
 
-.. versionadded:: 0.6.0
+<div class="versionadded">
+
+0.6.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS318.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS318.md
@@ -3,35 +3,37 @@ code: 318
 title: Found extra indentation
 ---
 
-
 Forbid extra indentation.
 
-Reasoning:
-    You can use extra indentation for lines of code.
-    Python allows you to do that in case you want to keep the
-    indentation level equal for this specific node,
-    but that's insane!
+  - Reasoning:  
+    You can use extra indentation for lines of code. Python allows you
+    to do that in case you want to keep the indentation level equal for
+    this specific node, but that's insane\!
 
-Solution:
-    We should stick to 4 spaces for an indentation block.
-    Each next block level should be indented by just 4 extra spaces.
+  - Solution:  
+    We should stick to 4 spaces for an indentation block. Each next
+    block level should be indented by just 4 extra spaces.
 
-Example::
+Example:
 
     # Correct:
     def test():
         print('test')
-
+    
     # Wrong:
     def test():
                 print('test')
 
 This rule is consistent with the "Vertical Hanging Indent" option for
-``multi_line_output`` setting of ``isort``. To avoid conflicting rules,
-you should set ``multi_line_output = 3`` in the ``isort`` settings.
+`multi_line_output` setting of `isort`. To avoid conflicting rules, you
+should set `multi_line_output = 3` in the `isort` settings.
 
-See also:
-    https://github.com/timothycrosley/isort#multi-line-output-modes
-    https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/isort.toml
+  - See also:  
+    <https://github.com/timothycrosley/isort#multi-line-output-modes>
+    <https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/isort.toml>
 
-.. versionadded:: 0.6.0
+<div class="versionadded">
+
+0.6.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS319.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS319.md
@@ -3,47 +3,51 @@ code: 319
 title: Found bracket in wrong position
 ---
 
-
 Forbid brackets in the wrong position.
 
-Reasoning:
-    You can do bizarre things with bracket positioning in python.
-    We require all brackets to be consistent.
+  - Reasoning:  
+    You can do bizarre things with bracket positioning in python. We
+    require all brackets to be consistent.
 
-Solution:
+  - Solution:  
     Place bracket on the same line, in case of a single line expression.
-    Or place the bracket on a new line in case of a multi-line expression.
+    Or place the bracket on a new line in case of a multi-line
+    expression.
 
-Example::
+Example:
 
     # Correct:
     print([
         1, 2, 3,
     ])
-
+    
     print(
         1,
         2,
     )
-
+    
     def _annotate_brackets(
         tokens: List[tokenize.TokenInfo],
     ) -> TokenLines:
         ...
-
+    
     # Wrong:
     print([
         1, 2, 3],
     )
-
+    
     print(
         1,
         2)
-
+    
     def _annotate_brackets(
         tokens: List[tokenize.TokenInfo]) -> TokenLines:
         ...
 
 We check round, square, and curly brackets.
 
-.. versionadded:: 0.6.0
+<div class="versionadded">
+
+0.6.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS320.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS320.md
@@ -3,22 +3,21 @@ code: 320
 title: Found multi-line function type annotation
 ---
 
-
 Forbid multi-line function type annotations.
 
-Reasoning:
+  - Reasoning:  
     Functions with multi-line type annotations are unreadable.
 
-Solution:
-    Use type annotations that fit into a single line to annotate functions.
-    If your annotation is too long, then use type aliases.
+  - Solution:  
+    Use type annotations that fit into a single line to annotate
+    functions. If your annotation is too long, then use type aliases.
 
-Example::
+Example:
 
     # Correct:
     def create_list(length: int) -> List[int]:
         ...
-
+    
     # Wrong:
     def create_list(length: int) -> List[
         int,
@@ -27,4 +26,8 @@ Example::
 
 This rule checks argument and return type annotations.
 
-.. versionadded:: 0.6.0
+<div class="versionadded">
+
+0.6.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS321.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS321.md
@@ -3,23 +3,26 @@ code: 321
 title: 'Found uppercase string modifier: {0}'
 ---
 
-
 Forbid uppercase string modifiers.
 
-Reasoning:
+  - Reasoning:  
     String modifiers should be consistent.
 
-Solution:
+  - Solution:  
     Use lowercase string modifiers.
 
-Example::
+Example:
 
     # Correct:
     some_string = r'/regex/'
     some_bytes = b'123'
-
+    
     # Wrong:
     some_string = R'/regex/'
     some_bytes = B'123'
 
-.. versionadded:: 0.6.0
+<div class="versionadded">
+
+0.6.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS322.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS322.md
@@ -3,17 +3,16 @@ code: 322
 title: Found incorrect multi-line string
 ---
 
-
 Forbid triple quotes for singleline strings.
 
-Reasoning:
+  - Reasoning:  
     String quotes should be consistent.
 
-Solution:
-    Use single quotes for single-line strings.
-    Triple quotes are only allowed for real multiline strings.
+  - Solution:  
+    Use single quotes for single-line strings. Triple quotes are only
+    allowed for real multiline strings.
 
-Example::
+Example:
 
     # Correct:
     single_line = 'abc'
@@ -21,12 +20,16 @@ Example::
         one
         two
     """
-
+    
     # Wrong:
     some_string = """abc"""
     some_bytes = b"""123"""
 
-Docstrings are ignored from this rule.
-You must use triple quotes strings for docstrings.
+Docstrings are ignored from this rule. You must use triple quotes
+strings for docstrings.
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS323.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS323.md
@@ -3,43 +3,45 @@ code: 323
 title: Found `%` string formatting
 ---
 
+Forbid `%` formatting on strings.
 
-Forbid ``%`` formatting on strings.
+We check for string formatting. We try not to issue false positives. It
+is better for us to ignore a real (but hard to detect) case, then
+marking a valid one as incorrect.
 
-We check for string formatting. We try not to issue false positives.
-It is better for us to ignore a real (but hard to detect) case,
-then marking a valid one as incorrect.
-
-Internally we check for this pattern in string definitions::
+Internally we check for this pattern in string definitions:
 
     %[(name)] [flags] [width] [.precision] [{h | l}] type
 
-This is a ``C`` format specification.
-Related to :class:`~FormattedStringViolation` and solves the same problem.
+This is a `C` format specification. Related to
+`~FormattedStringViolation` and solves the same problem.
 
-Reasoning:
+  - Reasoning:  
     You must use a single formatting method across your project.
 
-Solution:
-    We enforce to use string ``.format()`` method for this task.
+  - Solution:  
+    We enforce to use string `.format()` method for this task.
 
-Example::
+Example:
 
     # Correct:
     'some string', 'your name: {0}', 'data: {data}'
-
+    
     # Wrong:
     'my name is: %s', 'data: %(data)d'
 
-It might be a good idea to disable this rule
-and switch to ``flake8-pep3101`` in case your project
-has a lot of false-positives due
-to some specific string chars that uses ``%`` a lot.
+It might be a good idea to disable this rule and switch to
+`flake8-pep3101` in case your project has a lot of false-positives due
+to some specific string chars that uses `%` a lot.
 
-See also:
-    https://github.com/gforcada/flake8-pep3101
-    https://msdn.microsoft.com/en-us/library/56e442dc.aspx
-    https://docs.python.org/3/library/stdtypes.html#old-string-formatting
-    https://pyformat.info/
+  - See also:  
+    <https://github.com/gforcada/flake8-pep3101>
+    <https://msdn.microsoft.com/en-us/library/56e442dc.aspx>
+    <https://docs.python.org/3/library/stdtypes.html#old-string-formatting>
+    <https://pyformat.info/>
 
-.. versionadded:: 0.14.0
+<div class="versionadded">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS324.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS324.md
@@ -3,37 +3,39 @@ code: 324
 title: Found inconsistent `return` statement
 ---
 
+Enforce consistent `return` statements.
 
-Enforce consistent ``return`` statements.
+Rules are: 1. if any `return` has a value, all `return` nodes should
+have a value 2. do not place `return` without a value at the end of a
+function
 
-Rules are:
-1. if any ``return`` has a value, all ``return`` nodes should have a value
-2. do not place ``return`` without a value at the end of a function
+This rule respects `mypy` style of placing `return` statements. There
+should be no conflict with these two checks.
 
-This rule respects ``mypy`` style of placing ``return`` statements.
-There should be no conflict with these two checks.
-
-Reasoning:
+  - Reasoning:  
     This is done for pure consistency and readability of your code.
     Eventually, this rule may also find some bugs in your code.
 
-Solution:
-    Add or remove values from the ``return`` statements
-    to make them consistent.
-    Remove ``return`` statement from the function end.
+  - Solution:  
+    Add or remove values from the `return` statements to make them
+    consistent. Remove `return` statement from the function end.
 
-Example::
+Example:
 
     # Correct:
     def function():
         if some:
             return 2
         return 1
-
+    
     # Wrong:
     def function():
         if some:
             return
         return 1
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS325.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS325.md
@@ -3,35 +3,38 @@ code: 325
 title: Found inconsistent `yield` statement
 ---
 
+Enforce consistent `yield` statements.
 
-Enforce consistent ``yield`` statements.
+Rules are: 1. if any `yield` has a value, all `yield` nodes should have
+a value
 
-Rules are:
-1. if any ``yield`` has a value, all ``yield`` nodes should have a value
+This rule respects `mypy` style of placing `yield` statements. There
+should be no conflict with these two checks.
 
-This rule respects ``mypy`` style of placing ``yield`` statements.
-There should be no conflict with these two checks.
-
-Reasoning:
+  - Reasoning:  
     This is done for pure consistency and readability of your code.
     Eventually, this rule may also find some bugs in your code.
 
-Solution:
-    Add or remove values from the ``yield`` statements
-    to make them consistent.
+  - Solution:  
+    Add or remove values from the `yield` statements to make them
+    consistent.
 
-Example::
+Example:
 
     # Correct:
     def function():
         if some:
             yield 2
         yield 1
-
+    
     # Wrong:
     def function():
         if some:
             yield
         yield 1
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS326.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS326.md
@@ -3,24 +3,27 @@ code: 326
 title: Found implicit string concatenation
 ---
 
-
 Forbid implicit string concatenation.
 
-Reasoning:
-    This is error-prone, since you can possibly miss a comma
-    in a collection of strings and get an implicit concatenation.
-    And because there are safer ways to do the same thing
-    it is better to use them instead.
+  - Reasoning:  
+    This is error-prone, since you can possibly miss a comma in a
+    collection of strings and get an implicit concatenation. And because
+    there are safer ways to do the same thing it is better to use them
+    instead.
 
-Solution:
-    Use ``+`` or ``.format()`` to join strings.
+  - Solution:  
+    Use `+` or `.format()` to join strings.
 
-Example::
+Example:
 
     # Correct:
     text = 'first' + 'second'
-
+    
     # Wrong:
     text = 'first' 'second'
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS327.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS327.md
@@ -3,38 +3,41 @@ code: 327
 title: Found useless `continue` at the end of the loop
 ---
 
+Forbid meaningless `continue` in loops.
 
-Forbid meaningless ``continue`` in loops.
-
-Reasoning:
-    Placing this keyword at the end of any loop won't make any difference
-    to your code. And we prefer not to have meaningless
+  - Reasoning:  
+    Placing this keyword at the end of any loop won't make any
+    difference to your code. And we prefer not to have meaningless
     constructs in our code.
 
-Solution:
-    Remove useless ``continue`` from the loop.
+  - Solution:  
+    Remove useless `continue` from the loop.
 
-Example::
+Example:
 
     # Correct:
     for number in [1, 2, 3]:
         if number < 2:
             continue
         print(number)
-
+    
     for number in [1, 2, 3]:
         with suppress(Exception):
             do_smth(some_obj)
-
+    
     # Wrong:
     for number in [1, 2, 3]:
         print(number)
         continue
-
+    
     for number in [1, 2, 3]:
         try:
             do_smth(some_obj)
         except Exception:
             continue
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS328.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS328.md
@@ -3,22 +3,25 @@ code: 328
 title: 'Found useless node: {0}'
 ---
 
-
 Forbid meaningless nodes.
 
-Reasoning:
-    Some nodes might be completely useless. They will literally do nothing.
-    Sometimes they are hard to find, because this situation can be caused
-    by a recent refactoring or just by accident.
-    This might be also an overuse of syntax.
+  - Reasoning:  
+    Some nodes might be completely useless. They will literally do
+    nothing. Sometimes they are hard to find, because this situation can
+    be caused by a recent refactoring or just by accident. This might be
+    also an overuse of syntax.
 
-Solution:
+  - Solution:  
     Remove node or make sure it makes sense.
 
-Example::
+Example:
 
     # Wrong:
     for number in [1, 2, 3]:
         break
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS329.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS329.md
@@ -3,19 +3,18 @@ code: 329
 title: Found useless `except` case
 ---
 
+Forbid meaningless `except` cases.
 
-Forbid meaningless ``except`` cases.
+  - Reasoning:  
+    Using `except` cases that just reraise the same exception is
+    error-prone. You can increase your stacktrace, silence some
+    potential exceptions, and screw things up. It also does not make any
+    sense to do so.
 
-Reasoning:
-    Using ``except`` cases that just reraise the same exception
-    is error-prone. You can increase your stacktrace,
-    silence some potential exceptions, and screw things up.
-    It also does not make any sense to do so.
+  - Solution:  
+    Remove `except` case or make sure it makes sense.
 
-Solution:
-    Remove ``except`` case or make sure it makes sense.
-
-Example::
+Example:
 
     # Correct:
     try:
@@ -23,16 +22,20 @@ Example::
     except IndexError:
         sentry.log()
         raise ValueError()
-
+    
     try:
         ...
     except ValueError as exc:
         raise CustomReadableException from exc
-
+    
     # Wrong:
     try:
         ...
     except TypeError:
         raise
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS330.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS330.md
@@ -3,27 +3,26 @@ code: 330
 title: 'Found unnecessary operator: {0}'
 ---
 
-
 Forbid unnecessary operators in your code.
 
-You can write: ``5.4`` and ``+5.4``. There's no need to use the second
-version. Similarly ``--5.4``, ``---5.4``, ``not not foo``, and ``~~42``
-contain unnecessary operators.
+You can write: `5.4` and `+5.4`. There's no need to use the second
+version. Similarly `--5.4`, `---5.4`, `not not foo`, and `~~42` contain
+unnecessary operators.
 
-Reasoning:
+  - Reasoning:  
     This is done for consistency reasons.
 
-Solution:
+  - Solution:  
     Omit unnecessary operators.
 
-Example::
+Example:
 
     # Correct:
     profit = 3.33
     profit = -3.33
     inverse = ~5
     complement = not foo
-
+    
     # Wrong:
     profit = +3.33
     profit = --3.33
@@ -31,4 +30,8 @@ Example::
     number = ~~42
     bar = not not foo
 
-.. versionadded:: 0.8.0
+<div class="versionadded">
+
+0.8.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS331.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS331.md
@@ -3,40 +3,47 @@ code: 331
 title: 'Found variables that are only used for `return`: {0}'
 ---
 
+Forbid local variables that are only used in `return` statements.
 
-Forbid local variables that are only used in ``return`` statements.
+We also allow cases when a variable is assigned, then there are some
+other statements without direct variable access and the variable is
+returned. We reserve this use-case to be able to do some extra work
+before the function returns.
 
-We also allow cases when a variable is assigned,
-then there are some other statements without direct variable access
-and the variable is returned.
-We reserve this use-case to be able
-to do some extra work before the function returns.
+We also allow the return of partial, sorted, or modified tuple items
+that are defined just above.
 
-We also allow the return of partial, sorted,
-or modified tuple items that are defined just above.
-
-Reasoning:
+  - Reasoning:  
     This is done for consistency and more readable source code.
 
-Solution:
-    Return the expression itself, instead of creating a temporary variable.
+  - Solution:  
+    Return the expression itself, instead of creating a temporary
+    variable.
 
-Example::
+Example:
 
     # Correct:
     def some_function():
         return 1
-
+    
     def other_function():
         some_value = 1
         do_something(some_value)
         return some_value
-
+    
     # Wrong:
     def some_function():
         some_value = 1
         return some_value
 
+<div class="versionadded">
 
-.. versionadded:: 0.9.0
-.. versionchanged:: 0.14.0
+0.9.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS332.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS332.md
@@ -3,29 +3,31 @@ code: 332
 title: Found walrus operator
 ---
 
+Forbid local variable that are only used in `return` statements.
 
-Forbid local variable that are only used in ``return`` statements.
+This violation can only be thrown on `python3.8+`.
 
-This violation can only be thrown on ``python3.8+``.
-
-Reasoning:
-    Code with ``:=`` is hardly readable.
-    It has big problems with scoping and reading order.
-    And it can lead to a huge mess inside your code.
+  - Reasoning:  
+    Code with `:=` is hardly readable. It has big problems with scoping
+    and reading order. And it can lead to a huge mess inside your code.
     Python is not expression-based.
 
-Solution:
+  - Solution:  
     Don't use fancy stuff, use good old assignments.
 
-Example::
+Example:
 
     # Correct:
     some = call()
     if some:
         print(some)
-
+    
     # Wrong:
     if some := call():
         print(some)
 
-.. versionadded:: 0.14.0
+<div class="versionadded">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS333.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS333.md
@@ -3,25 +3,28 @@ code: 333
 title: Found implicit complex compare
 ---
 
-
 Forbid implicit complex comparison expressions.
 
-Reasoning:
-    Two comparisons in python that are joined with ``and`` operator
-    mean that you have a complex comparison with tree operators.
+  - Reasoning:  
+    Two comparisons in python that are joined with `and` operator mean
+    that you have a complex comparison with tree operators.
 
-Solution:
-    Refactor your comparison without ``and`` but with the third operator.
+  - Solution:  
+    Refactor your comparison without `and` but with the third operator.
     Notice that you might have to change the ordering.
 
-Example::
+Example:
 
     # Correct:
     if three < two < one:
         ...
-
+    
     # Wrong:
     if one > two and two > three:
         ...
 
-.. versionadded:: 0.10.0
+<div class="versionadded">
+
+0.10.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS334.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS334.md
@@ -3,27 +3,30 @@ code: 334
 title: Found reversed complex comparison
 ---
 
-
 Forbid reversed order complex comparison expressions.
 
-Reasoning:
-    Comparisons where comparators start from the lowest element
-    are easier to read than one that start from the biggest one.
-    It is also possible to write the same expression
-    in two separate way, which is inconsistent.
+  - Reasoning:  
+    Comparisons where comparators start from the lowest element are
+    easier to read than one that start from the biggest one. It is also
+    possible to write the same expression in two separate way, which is
+    inconsistent.
 
-Solution:
-    Reverse the order, so the smallest element comes first
-    and the biggest one comes last.
+  - Solution:  
+    Reverse the order, so the smallest element comes first and the
+    biggest one comes last.
 
-Example::
+Example:
 
     # Correct:
     if three < two < one:
         ...
-
+    
     # Wrong:
     if one > two > three:
         ...
 
-.. versionadded:: 0.10.0
+<div class="versionadded">
+
+0.10.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS335.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS335.md
@@ -3,36 +3,45 @@ code: 335
 title: Found incorrect `for` loop iter type
 ---
 
-
-Forbid wrong ``for`` loop iter targets.
+Forbid wrong `for` loop iter targets.
 
 We forbid to use:
 
-- Lists and list comprehensions
-- Sets and set comprehensions
-- Dicts and dict comprehensions
-- Generator expressions
-- Empty tuples
+  - Lists and list comprehensions
+  - Sets and set comprehensions
+  - Dicts and dict comprehensions
+  - Generator expressions
+  - Empty tuples
 
-Reasoning:
-    Using lists, dicts, and sets do not make much sense.
-    You can use tuples instead.
-    Using comprehensions implicitly creates a two level loop,
-    that is hard to read and deal with.
+<!-- end list -->
 
-Solution:
-    Use tuples to create explicit iterables for ``for`` loops.
-    In case you are using a comprehension, create a new variable.
+  - Reasoning:  
+    Using lists, dicts, and sets do not make much sense. You can use
+    tuples instead. Using comprehensions implicitly creates a two level
+    loop, that is hard to read and deal with.
 
-Example::
+  - Solution:  
+    Use tuples to create explicit iterables for `for` loops. In case you
+    are using a comprehension, create a new variable.
+
+Example:
 
     # Correct:
     for person in ('Kim', 'Nick'):
         ...
-
+    
     # Wrong:
     for person in ['Kim', 'Nick']:
         ...
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS336.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS336.md
@@ -3,26 +3,29 @@ code: 336
 title: Found explicit string concatenation
 ---
 
+Forbid explicit string concatanation in favour of `.format` method.
 
-Forbid explicit string concatanation in favour of ``.format`` method.
+However, we still allow multiline string concatanation as a way to write
+long strings that does not fit the 80-chars rule.
 
-However, we still allow multiline string concatanation
-as a way to write long strings that does not fit the 80-chars rule.
+  - Reasoning:  
+    When formatting strings one must use `.format` and not any other
+    formatting methods like `%`, `+`, or `f`. This is done for
+    consistency reasons.
 
-Reasoning:
-    When formatting strings one must use ``.format``
-    and not any other formatting methods like ``%``, ``+``, or ``f``.
-    This is done for consistency reasons.
+  - Solution:  
+    Join strings together if you can, or use `.format` method.
 
-Solution:
-    Join strings together if you can, or use ``.format`` method.
-
-Example::
+Example:
 
     # Correct:
     x = 'ab: {0}'.format(some_data)
-
+    
     # Wrong:
     x = 'a' + 'b: ' + some_data
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS337.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS337.md
@@ -3,24 +3,23 @@ code: 337
 title: Found multiline conditions
 ---
 
-
 Forbid multiline conditions.
 
-Reasoning:
-    This way of writing conditions hides the inner complexity this line has
-    and it decreases readability of the code.
+  - Reasoning:  
+    This way of writing conditions hides the inner complexity this line
+    has and it decreases readability of the code.
 
-Solution:
-    Divide multiline conditions to some ``if`` condition or use variables.
+  - Solution:  
+    Divide multiline conditions to some `if` condition or use variables.
 
-Example::
+Example:
 
     # Correct:
     if isinstance(node.test, ast.UnaryOp):
         if isinstance(node.test.op, ast.Not):
             ...
-
-
+    
+    
     # Wrong:
     if isinstance(node.test, ast.UnaryOp) and isinstance(
         node.test.op,
@@ -28,5 +27,14 @@ Example::
     ):
         ...
 
-.. versionadded:: 0.9.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.9.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS338.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS338.md
@@ -3,27 +3,30 @@ code: 338
 title: Found incorrect order of methods in a class
 ---
 
-
 Forbid incorrect order of methods inside a class.
 
 We follow the same ordering:
 
-- ``__new__``
-- ``__init__``
-- ``__call__``
-- ``__await__``
-- public and magic methods
-- protected methods
-- private methods (we discourage using them)
+  - `__new__`
+  - `__init__`
+  - `__call__`
+  - `__await__`
+  - public and magic methods
+  - protected methods
+  - private methods (we discourage using them)
 
 We follow "Newspaper order" where the most important things come first.
 
-Reasoning:
+  - Reasoning:  
     It is hard to read classes where API declarations are bloated with
     implementation details. We need to see the important stuff first,
     then we can go deeper in case we are interested.
 
-Solution:
+  - Solution:  
     Reorder methods inside your class to match our format.
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS339.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS339.md
@@ -3,29 +3,31 @@ code: 339
 title: 'Found number with meaningless zeros: {0}'
 ---
 
-
 Forbid meaningless zeros.
 
-We discourage using meaningless zeros in
-float, binary, octal, hex, and exponential numbers.
+We discourage using meaningless zeros in float, binary, octal, hex, and
+exponential numbers.
 
-Reasoning:
-    There are ~infinite ways to write these numbers
-    by adding meaningless leading zeros to the number itself.
-    ``0b1`` is the same as ``0b01`` and ``0b001``.
-    How can a language be called consistent
-    if you can write numbers in an infinite ways?
-    It hurts readability and understanding of your code.
+  - Reasoning:  
+    There are \~infinite ways to write these numbers by adding
+    meaningless leading zeros to the number itself. `0b1` is the same as
+    `0b01` and `0b001`. How can a language be called consistent if you
+    can write numbers in an infinite ways? It hurts readability and
+    understanding of your code.
 
-Solution:
+  - Solution:  
     Remove meaningless leading zeros.
 
-Example::
+Example:
 
     # Correct:
     numbers = [1.5, 0b1, 0o2, 0x5, 10e10]
-
+    
     # Wrong:
     numbers = [1.50, 0b00000001, 0o0002, 0x05, 10e010]
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS340.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS340.md
@@ -3,23 +3,25 @@ code: 340
 title: 'Found exponent number with positive exponent: {0}'
 ---
 
+Forbid extra `+` signs in the exponent.
 
-Forbid extra ``+`` signs in the exponent.
+  - Reasoning:  
+    Positive exponent is positive by default, there's no need to write
+    an extra `+` sign. We enforce consistency with this rule.
 
-Reasoning:
-    Positive exponent is positive by default,
-    there's no need to write an extra ``+`` sign.
-    We enforce consistency with this rule.
+  - Solution:  
+    Remove meaningless `+` sign from the exponent.
 
-Solution:
-    Remove meaningless ``+`` sign from the exponent.
-
-Example::
+Example:
 
     # Correct:
     number = 1e1 + 1e-1
-
+    
     # Wrong:
     number = 1e+1
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS341.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS341.md
@@ -3,22 +3,25 @@ code: 341
 title: 'Found wrong hex number case: {0}'
 ---
 
-
 Forbid letters as hex numbers.
 
-Reasoning:
-    One can write ``0xA`` and ``0xa`` which is inconsistent.
-    This rule enforces upper-case letters in hex numbers.
+  - Reasoning:  
+    One can write `0xA` and `0xa` which is inconsistent. This rule
+    enforces upper-case letters in hex numbers.
 
-Solution:
+  - Solution:  
     Use uppercase letters in hex numbers.
 
-Example::
+Example:
 
     # Correct:
     number = 0xABCDEF
-
+    
     # Wrong:
     number = 0xabcdef
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS342.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS342.md
@@ -3,23 +3,26 @@ code: 342
 title: 'Found implicit raw string: {0}'
 ---
 
+Forbid `\\` escape sequences inside regular strings.
 
-Forbid ``\\`` escape sequences inside regular strings.
+  - Reasoning:  
+    It is hard to read escape sequences inside regular strings, because
+    they use `\\` double backslash for a single character escape.
 
-Reasoning:
-    It is hard to read escape sequences inside regular strings,
-    because they use ``\\`` double backslash for a single character escape.
+  - Solution:  
+    Use raw strings `r''` to rewrite the escape sequence with a `\`
+    single backslash.
 
-Solution:
-    Use raw strings ``r''`` to rewrite
-    the escape sequence with a ``\`` single backslash.
-
-Example::
+Example:
 
     # Correct:
     escaped = [r'\n', '\n']
-
+    
     # Wrong:
     escaped = '\\n'
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS343.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS343.md
@@ -3,21 +3,24 @@ code: 343
 title: 'Found wrong complex number suffix: {0}'
 ---
 
-
 Forbid uppercase complex number suffix.
 
-Reasoning:
+  - Reasoning:  
     Numbers should be consistent.
 
-Solution:
+  - Solution:  
     Use lowercase suffix for imaginary part.
 
-Example::
+Example:
 
     # Correct:
     complex_number = 1j
-
+    
     # Wrong:
     complex_number = 1J
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS344.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS344.md
@@ -3,26 +3,27 @@ code: 344
 title: Found explicit zero division
 ---
 
-
 Forbid explicit division (or modulo) by zero.
 
-Reasoning:
-    This will just throw ``ZeroDivisionError``.
-    If that's what you need: just throw it.
-    No need to use undefined math behaviours.
-    Or it might be just a typo / mistake, then fix it.
+  - Reasoning:  
+    This will just throw `ZeroDivisionError`. If that's what you need:
+    just throw it. No need to use undefined math behaviours. Or it might
+    be just a typo / mistake, then fix it.
 
-Solution:
-    Use ``ZeroDivisionError`` or make your number something besides ``0``.
+  - Solution:  
+    Use `ZeroDivisionError` or make your number something besides `0`.
 
-Example::
+Example:
 
     # Correct:
     raise ZeroDivisionError()
-
+    
     # Wrong:
     1 / 0
     1 % 0
 
-.. versionadded:: 0.12.0
-.. versionchanged: 0.15.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS345.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS345.md
@@ -3,29 +3,26 @@ code: 345
 title: Found meaningless number operation
 ---
 
+Forbid meaningless math operations with `0` and `1`.
 
-Forbid meaningless math operations with ``0`` and ``1``.
+  - Reasoning:  
+    Adding and subtracting zero does not change the value. There's no
+    need to do that. Multiplying by zero is also redundant: it can be
+    replaced with explicit `0` assign. Multiplying and dividing by `1`
+    is also meaningless. Likewise, using `|` or `^` with `0`, and using
+    the `%` operator with `1` are unnecessary.
 
-Reasoning:
-    Adding and subtracting zero does not change the value.
-    There's no need to do that.
-    Multiplying by zero is also redundant:
-    it can be replaced with explicit ``0`` assign.
-    Multiplying and dividing by ``1`` is also meaningless.
-    Likewise, using ``|`` or ``^`` with ``0``, and using
-    the ``%`` operator with ``1`` are unnecessary.
-
-Solution:
+  - Solution:  
     Remove useless operations.
 
-Example::
+Example:
 
     # Correct:
     number = 1
     zero = 0
     one = 1
     three = 3
-
+    
     # Wrong:
     number = 1 + 0 * 1
     zero = some * 0 / 1
@@ -34,5 +31,14 @@ Example::
     three = 3 | 0
     three = 3 % 1
 
-.. versionadded:: 0.12.0
-.. versionchanged:: 0.15.0
+<div class="versionadded">
+
+0.12.0
+
+</div>
+
+<div class="versionchanged">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS346.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS346.md
@@ -3,29 +3,31 @@ code: 346
 title: Found wrong operation sign
 ---
 
-
 Forbid double minus operations.
 
-Reasoning:
-    Having two operations is harder than having just one.
-    Two negations are harder than one positive expression.
-    Two negations equal to one positive expression.
-    Positive and negative equal to one negative.
+  - Reasoning:  
+    Having two operations is harder than having just one. Two negations
+    are harder than one positive expression. Two negations equal to one
+    positive expression. Positive and negative equal to one negative.
 
-Solution:
-    Replace double minus operation to a single one with plus.
-    Replace 'plus-minus' operation to a single one with minus.
+  - Solution:  
+    Replace double minus operation to a single one with plus. Replace
+    'plus-minus' operation to a single one with minus.
 
-Example::
+Example:
 
     # Correct:
     number = 3 + 1
     number += 6
     number -= 2
-
+    
     # Wrong:
     number = 3 - -1
     number -= -6
     number += -2
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS347.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS347.md
@@ -3,37 +3,46 @@ code: 347
 title: 'Found vague import that may cause confusion: {0}'
 ---
 
-
 Forbid imports that may cause confusion outside of the module.
 
 Names that we forbid to import:
 
-- Common names like ``dumps`` and ``loads``
-- Names starting with ``to_`` and ``from_``
-- Too short names like ``Q`` or ``F``, but we are fine with ``_``
+  - Common names like `dumps` and `loads`
+  - Names starting with `to_` and `from_`
+  - Too short names like `Q` or `F`, but we are fine with `_`
 
-Reasoning:
-    See ``datetime.*`` in code? You know that it's from datetime.
-    See ``BaseView`` in a Django project? You know where it is from.
-    See ``loads``? It can be anything: ``yaml``, ``toml``, ``json``, etc.
-    We are also enforcing consistency with our naming too-short rules here.
+<!-- end list -->
 
-Solution:
+  - Reasoning:  
+    See `datetime.*` in code? You know that it's from datetime. See
+    `BaseView` in a Django project? You know where it is from. See
+    `loads`? It can be anything: `yaml`, `toml`, `json`, etc. We are
+    also enforcing consistency with our naming too-short rules here.
+
+  - Solution:  
     Use package level imports or import aliases.
 
-See
-:py:data:`~wemake_python_styleguide.constants.VAGUE_IMPORTS_BLACKLIST`
-for the full list of bad import names.
+See :py`~wemake_python_styleguide.constants.VAGUE_IMPORTS_BLACKLIST` for
+the full list of bad import names.
 
-Example::
+Example:
 
     # Correct:
     import json
     import dumps  # package names are not checked
     from json import loads as json_loads
-
+    
     # Wrong:
     from json import loads
 
-.. versionadded:: 0.13.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
+
+0.13.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS348.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS348.md
@@ -3,18 +3,17 @@ code: 348
 title: Found a line that starts with a dot
 ---
 
-
 Forbid starting lines with a dot.
 
-Reasoning:
-    We enforce strict consistency rules about how to break lines.
-    We also enforce strict rules about multi-line parameters.
-    Starting new lines with the dot means that this rule is broken.
+  - Reasoning:  
+    We enforce strict consistency rules about how to break lines. We
+    also enforce strict rules about multi-line parameters. Starting new
+    lines with the dot means that this rule is broken.
 
-Solution:
-    Use ``()`` to break lines in a complex expression.
+  - Solution:  
+    Use `()` to break lines in a complex expression.
 
-Example::
+Example:
 
     # Correct:
     some = MyModel.objects.filter(
@@ -24,7 +23,7 @@ Example::
     ).annotate(
         ...,
     )
-
+    
     # Wrong
     some = (
         MyModel.objects.filter(...)
@@ -32,4 +31,8 @@ Example::
             .annotate(...)
     )
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS349.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS349.md
@@ -3,20 +3,23 @@ code: 349
 title: Found redundant subscript slice
 ---
 
-
 Forbid redundant components in a subscript's slice.
 
-Reasoning:
+  - Reasoning:  
     We do it for consistency reasons.
 
-Example::
+Example:
 
     # Correct:
     array[:7]
     array[3:]
-
+    
     # Wrong:
     x[0:7]
     x[3:None]
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS350.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS350.md
@@ -3,19 +3,22 @@ code: 350
 title: Found usable augmented assign pattern
 ---
 
-
 Enforce using augmented assign pattern.
 
-Reasoning:
-    ``a += b`` is short and correct version of ``a = a + b``.
-    Why not using the short version?
+  - Reasoning:  
+    `a += b` is short and correct version of `a = a + b`. Why not using
+    the short version?
 
-Example::
+Example:
 
     # Correct:
     a += b
-
+    
     # Wrong:
     a = a + b
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS351.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS351.md
@@ -3,22 +3,25 @@ code: 351
 title: Found unnecessary literals
 ---
 
-
 Forbid unnecessary literals in your code.
 
-Reasoning:
+  - Reasoning:  
     We discourage using primitive calls to get default type values.
     There are better ways to get these values.
 
-Solution:
+  - Solution:  
     Use direct default values of the given type
 
-Example::
+Example:
 
     # Correct:
     default = 0
-
+    
     # Wrong:
     default = int()
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS352.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS352.md
@@ -3,22 +3,21 @@ code: 352
 title: Found multiline loop
 ---
 
-
 Forbid multiline loops.
 
-Reasoning:
+  - Reasoning:  
     It decreased the readability of the code.
 
-Solution:
-    Use single line loops and create new variables
-    in case you need to fit too many logic inside the loop definition.
+  - Solution:  
+    Use single line loops and create new variables in case you need to
+    fit too many logic inside the loop definition.
 
-Example::
+Example:
 
     # Correct:
     for num in some_function(arg1, arg2):
         ...
-
+    
     # Wrong:
     for num in range(
         arg1,
@@ -26,4 +25,8 @@ Example::
     ):
         ...
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS353.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS353.md
@@ -3,28 +3,30 @@ code: 353
 title: Found incorrect `yield from` target
 ---
 
+Forbid `yield from` with several nodes.
 
-Forbid ``yield from`` with several nodes.
+We allow to `yield from` tuples, names, attributes, calls, and
+subscripts.
 
-We allow to ``yield from`` tuples,
-names, attributes, calls, and subscripts.
+  - Reasoning:  
+    We enforce consistency when yielding values from tuple instead of
+    any other types. It also might be an error when you try to `yield
+    from` something that is not iterable.
 
-Reasoning:
-    We enforce consistency when yielding values
-    from tuple instead of any other types.
-    It also might be an error when you try to ``yield from`` something
-    that is not iterable.
+  - Solution:  
+    Use allowed node types with `yield from`.
 
-Solution:
-    Use allowed node types with ``yield from``.
-
-Example::
+Example:
 
     # Correct:
     yield from (1, 2, 3)
     yield from some
-
+    
     # Wrong:
     yield from [1, 2, 3]
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS354.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS354.md
@@ -3,17 +3,20 @@ code: 354
 title: Found consecutive `yield` expressions
 ---
 
+Forbid consecutive `yield` expressions.
 
-Forbid consecutive ``yield`` expressions.
+We raise this violation when we find at least two consecutive `yield`
+expressions.
 
-We raise this violation when we find at least
-two consecutive ``yield`` expressions.
+  - Reasoning:  
+    One can write multiple `yield` nodes in a row. That's inconsistent.
+    Because we have `yield from` form.
 
-Reasoning:
-    One can write multiple ``yield`` nodes in a row.
-    That's inconsistent. Because we have ``yield from`` form.
+  - Solution:  
+    It can be easily changed to `yield from (...)` format.
 
-Solution:
-    It can be easily changed to ``yield from (...)`` format.
+<div class="versionadded">
 
-.. versionadded:: 0.13.0
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS355.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS355.md
@@ -3,29 +3,32 @@ code: 355
 title: Found an unnecessary blank line before a bracket
 ---
 
-
 Forbid useless blank lines before and after brackets.
 
-Reasoning:
+  - Reasoning:  
     We do this for consistency.
 
-Solution:
+  - Solution:  
     Remove blank lines from the start and from the end of a collection.
 
-Example::
+Example:
 
     # Correct:
     arr = [
         1,
         2,
     ]
-
+    
     # Wrong:
     arr = [
-
+    
         1,
         2,
-
+    
     ]
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS356.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS356.md
@@ -3,25 +3,28 @@ code: 356
 title: Found an unnecessary iterable unpacking
 ---
 
-
 Forbid unnecessary iterable unpacking.
 
-Reasoning:
+  - Reasoning:  
     We do this for consistency.
 
-Solution:
+  - Solution:  
     Do not use iterable unpacking when it's not necessary.
 
-Example::
+Example:
 
     # Correct:
     [1, *numbers, 99]
     {*iterable, *other_iterable}
     list(iterable)
     first, *iterable = other_iterable
-
+    
     # Wrong:
     [*iterable]
     *iterable, = other_iterable
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS357.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS357.md
@@ -3,15 +3,17 @@ code: 357
 title: Found a ``\r`` (carriage return) line break
 ---
 
+Forbid using `\r` (carriage return) in line breaks.
 
-Forbid using ``\r`` (carriage return) in line breaks.
+  - Reasoning:  
+    We enforce Unix-style newlines. We only use newlines (`\n`), not
+    carriage returns. So `\r` line breaks not allowed in code.
 
-Reasoning:
-    We enforce Unix-style newlines.
-    We only use newlines (``\n``), not carriage returns.
-    So ``\r`` line breaks not allowed in code.
+  - Solution:  
+    Use only `\n` (not `\r\n` or `\r`) to break lines.
 
-Solution:
-    Use only ``\n`` (not ``\r\n`` or ``\r``) to break lines.
+<div class="versionadded">
 
-.. versionadded:: 0.14.0
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS358.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS358.md
@@ -3,24 +3,27 @@ code: 358
 title: Found a float zero (0.0)
 ---
 
+Forbid using float zeros: `0.0`.
 
-Forbid using float zeros: ``0.0``.
+  - Reasoning:  
+    Float zeros can be used as variable values which may lead to typing
+    bugs when trying to perform an operation between an int number and
+    the float zero.
 
-Reasoning:
-    Float zeros can be used as variable values which may lead to
-    typing bugs when trying to perform an operation between
-    an int number and the float zero.
-
-Solution:
+  - Solution:  
     Use int zeros (0). If a float is needed, it should be cast
     explicitly.
 
-Example::
+Example:
 
     # Correct:
     zero = 0
-
+    
     # Wrong:
     zero = 0.0
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS359.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS359.md
@@ -3,23 +3,26 @@ code: 359
 title: Found an iterable unpacking to list
 ---
 
-
 Forbids to unpack iterable objects to lists.
 
-Reasoning:
+  - Reasoning:  
     We do this for consistency.
 
-Solution:
+  - Solution:  
     Do not unpack iterables to lists, use tuples for that.
 
-Example::
+Example:
 
     # Correct:
     first, second = (7, 4)
     first, *iterable = other_iterable
-
+    
     # Wrong:
     [first, second] = (7, 4)
     [first, *iterable] = other_iterable
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS360.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS360.md
@@ -3,21 +3,24 @@ code: 360
 title: 'Found an unnecessary use of a raw string: {0}'
 ---
 
-
 Forbid the use of raw strings when there is no backslash in the string.
 
-Reasoning:
-    Raw string are only needed when dealing with ``\`` in the string.
+  - Reasoning:  
+    Raw string are only needed when dealing with `\` in the string.
 
-Solution:
-    Do not prefix the string with ``r``. Use a normal string instead.
+  - Solution:  
+    Do not prefix the string with `r`. Use a normal string instead.
 
-Example::
+Example:
 
     # Correct:
     r'This is a correct use \n'
-
+    
     # Wrong:
     r'This string should not be prefixed with r.'
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS361.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS361.md
@@ -3,32 +3,35 @@ code: 361
 title: Found an inconsistently structured comprehension
 ---
 
-
 Forbids inconsistent newlines in comprehensions.
 
-Reasoning:
+  - Reasoning:  
     We do this for consistency.
 
-Solution:
+  - Solution:  
     Either place comprehension on a single line or ensure that action,
     for loops, and condition are all on different lines.
 
-Example::
+Example:
 
     # Correct:
     list = [some(number) for number in numbers]
-
+    
     list = [
        some(number)
        for numbers in matrix
        for number in numbers
        if number > 0
     ]
-
+    
     # Wrong:
     list = [
         some(number) for number in numbers
         if number > 0
     ]
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS362.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS362.md
@@ -3,33 +3,36 @@ code: 362
 title: Found assignment to a subscript slice
 ---
 
-
 Forbid assignment to a subscript slice.
 
-Reasoning:
+  - Reasoning:  
     Assignment to a slice may lead to a list changing its size
     implicitly and strangely which makes it hard to spot bugs.
 
-Solution:
+  - Solution:  
     Use explicit index assignment in place of slice assignment.
 
 Why you may disable or inline-ignore this rule?
 
-The quite common and useful example which violates this rule
-is inplace list replacement via ``[:]`` - this helps
-to keep the same object reference while it content could be completely
-erased or replaced with the new one.
+The quite common and useful example which violates this rule is inplace
+list replacement via `[:]` - this helps to keep the same object
+reference while it content could be completely erased or replaced with
+the new one.
 
-One more thing: slice assignment is the only way
-for inplace array multiple replacement when you need that.
+One more thing: slice assignment is the only way for inplace array
+multiple replacement when you need that.
 
-Example::
+Example:
 
     # Correct:
     a[5] = 1
-
+    
     # Wrong:
     a[1:3] = [1, 2]
     a[slice(1)] = [1, 3]
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS400.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS400.md
@@ -3,42 +3,45 @@ code: 400
 title: 'Found wrong magic comment: {0}'
 ---
 
-
 Restrict various control (such as magic) comments.
 
 We do not allow:
 
-1. ``# noqa`` comment without specified violations
-2. ``# type: some_type`` comments to specify a type for ``typed_ast``
+1.  `# noqa` comment without specified violations
+2.  `# type: some_type` comments to specify a type for `typed_ast`
 
-This violation is reported at the top of the module,
-so it cannot be locally ignored.
+This violation is reported at the top of the module, so it cannot be
+locally ignored.
 
-Reasoning:
-    We cover several use-cases in a single rule.
-    ``# noqa`` comment is restricted because it can hide other violations.
-    ``# type: some_type`` comment is restricted because we can use type annotations instead.
+  - Reasoning:  
+    We cover several use-cases in a single rule. `# noqa` comment is
+    restricted because it can hide other violations. `# type: some_type`
+    comment is restricted because we can use type annotations instead.
 
-Solution:
-    Use ``# noqa`` comments with specified error types.
-    Use type annotations to specify types.
+  - Solution:  
+    Use `# noqa` comments with specified error types. Use type
+    annotations to specify types.
 
-We still allow using ``# type: ignore`` comment,
-since sometimes it is required.
+We still allow using `# type: ignore` comment, since sometimes it is
+required.
 
-Example::
+Example:
 
     # Correct:
     type = MyClass.get_type()  # noqa: WPS125
     coordinate: int = 10
     some.int_field = 'text'  # type: ignore
-
+    
     number: int
     for number in some_untyped_iterable():
         ...
-
+    
     # Wrong:
     type = MyClass.get_type()  # noqa
     coordinate = 10  # type: int
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS401.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS401.md
@@ -3,27 +3,30 @@ code: 401
 title: Found wrong doc comment
 ---
 
+Forbid empty doc comments (`#:`).
 
-Forbid empty doc comments (``#:``).
+  - Reasoning:  
+    Doc comments are used to provide documentation but supplying empty
+    doc comments breaks this use-case. It is unclear why they can be
+    used with no contents.
 
-Reasoning:
-    Doc comments are used to provide documentation
-    but supplying empty doc comments breaks this use-case.
-    It is unclear why they can be used with no contents.
-
-Solution:
+  - Solution:  
     Add some documentation to this comment or remove it.
 
-Empty doc comments are not caught by the default ``pycodestyle`` checks.
+Empty doc comments are not caught by the default `pycodestyle` checks.
 
-Example::
+Example:
 
     # Correct:
     #: List of allowed names:
     NAMES_WHITELIST = ['feature', 'bug', 'research']
-
+    
     # Wrong:
     #:
     NAMES_WHITELIST = ['feature', 'bug', 'research']
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS402.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS402.md
@@ -17,7 +17,7 @@ We count them on a per-module basis.
 
   - Configuration:  
     This rule is configurable with `--max-noqa-comments`. Default:
-    `wemake_python_styleguide.options.defaults.MAX_NOQA_COMMENTS`
+    `python://wemake_python_styleguide.options.defaults.MAX_NOQA_COMMENTS`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS402.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS402.md
@@ -3,23 +3,24 @@ code: 402
 title: 'Found `noqa` comments overuse: {0}'
 ---
 
-
-Forbid too many ``# noqa`` comments.
+Forbid too many `# noqa` comments.
 
 We count them on a per-module basis.
 
-Reasoning:
-    Having too many ``# noqa`` comments makes your code
-    less readable and indicates that there's something
-    wrong with it.
+  - Reasoning:  
+    Having too many `# noqa` comments makes your code less readable and
+    indicates that there's something wrong with it.
 
-Solution:
-    Refactor your code to match our style.
-    Or use a config file to switch off some checks.
+  - Solution:  
+    Refactor your code to match our style. Or use a config file to
+    switch off some checks.
 
-Configuration:
-    This rule is configurable with ``--max-noqa-comments``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.MAX_NOQA_COMMENTS`
+  - Configuration:  
+    This rule is configurable with `--max-noqa-comments`. Default:
+    `wemake_python_styleguide.options.defaults.MAX_NOQA_COMMENTS`
 
-.. versionadded:: 0.7.0
+<div class="versionadded">
+
+0.7.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS403.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS403.md
@@ -6,8 +6,8 @@ title: 'Found `noqa` comments overuse: {0}'
 Forbid too many `# pragma: no cover` comments.
 
 We count them on a per-module basis. We use
-`wemake_python_styleguide.constants.MAX_NO_COVER_COMMENTS` as a default
-value.
+`python://wemake_python_styleguide.constants.MAX_NO_COVER_COMMENTS` as a
+default value.
 
   - Reasoning:  
     Having too many `# pragma: no cover` comments indicates that there's

--- a/docs/wemake-python-styleguide/0.15.2/WPS403.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS403.md
@@ -3,21 +3,23 @@ code: 403
 title: 'Found `noqa` comments overuse: {0}'
 ---
 
+Forbid too many `# pragma: no cover` comments.
 
-Forbid too many ``# pragma: no cover`` comments.
+We count them on a per-module basis. We use
+`wemake_python_styleguide.constants.MAX_NO_COVER_COMMENTS` as a default
+value.
 
-We count them on a per-module basis.
-We use :str:`wemake_python_styleguide.constants.MAX_NO_COVER_COMMENTS`
-as a default value.
+  - Reasoning:  
+    Having too many `# pragma: no cover` comments indicates that there's
+    something wrong with the code. Moreover, it makes your tests
+    useless, since they do not cover a big portion of your code.
 
-Reasoning:
-    Having too many ``# pragma: no cover`` comments
-    indicates that there's something wrong with the code.
-    Moreover, it makes your tests useless, since they do not cover
-    a big portion of your code.
+  - Solution:  
+    Refactor your code to match the style. Or use a config file to
+    switch off some checks.
 
-Solution:
-    Refactor your code to match the style.
-    Or use a config file to switch off some checks.
+<div class="versionadded">
 
-.. versionadded:: 0.8.0
+0.8.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS404.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS404.md
@@ -3,28 +3,36 @@ code: 404
 title: Found complex default value
 ---
 
-
 Forbid complex defaults.
 
-Anything that is not a ``ast.Name``, ``ast.Attribute``, ``ast.Str``,
-``ast.NameConstant``, ``ast.Tuple``, ``ast.Bytes``, ``ast.Num``
-or ``ast.Ellipsis`` should be moved out from defaults.
+Anything that is not a `ast.Name`, `ast.Attribute`, `ast.Str`,
+`ast.NameConstant`, `ast.Tuple`, `ast.Bytes`, `ast.Num` or
+`ast.Ellipsis` should be moved out from defaults.
 
-Reasoning:
-    It can be tricky. Nothing stops you from making database calls or HTTP
-    requests in such expressions. It is also not readable for us.
+  - Reasoning:  
+    It can be tricky. Nothing stops you from making database calls or
+    HTTP requests in such expressions. It is also not readable for us.
 
-Solution:
+  - Solution:  
     Move the expression out from default value.
 
-Example::
+Example:
 
     # Correct:
     SHOULD_USE_DOCTEST = 'PYFLAKES_DOCTEST' in os.environ
     def __init__(self, with_doctest=SHOULD_USE_DOCTEST):
-
+    
     # Wrong:
     def __init__(self, with_doctest='PYFLAKES_DOCTEST' in os.environ):
 
-.. versionadded:: 0.8.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.8.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS405.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS405.md
@@ -3,27 +3,34 @@ code: 405
 title: Found wrong `for` loop variable definition
 ---
 
+Forbid anything other than `ast.Name` to define loop variables.
 
-Forbid anything other than ``ast.Name`` to define loop variables.
+  - Reasoning:  
+    When defining a `for` loop with attributes, indexes, calls, or any
+    other nodes it does dirty things inside.
 
-Reasoning:
-    When defining a ``for`` loop with attributes, indexes, calls,
-    or any other nodes it does dirty things inside.
-
-Solution:
-    Use regular ``ast.Name`` variables.
-    Or tuple of ``ast.Name`` variables.
+  - Solution:  
+    Use regular `ast.Name` variables. Or tuple of `ast.Name` variables.
     Star names are also fine.
 
-Example::
+Example:
 
     # Correct:
     for person in database.people():
         ...
-
+    
     # Wrong:
     for context['person'] in database.people():
         ...
 
-.. versionadded:: 0.8.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.8.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS406.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS406.md
@@ -3,27 +3,34 @@ code: 406
 title: Found wrong context manager variable definition
 ---
 
+Forbid anything other than `ast.Name` to define contexts.
 
-Forbid anything other than ``ast.Name`` to define contexts.
+  - Reasoning:  
+    When defining a `with` context managers with attributes, indexes,
+    calls, or any other nodes it does dirty things inside.
 
-Reasoning:
-    When defining a ``with`` context managers with attributes,
-    indexes, calls, or any other nodes it does dirty things inside.
-
-Solution:
-    Use regular ``ast.Name`` variables.
-    Or tuple of ``ast.Name`` variables.
+  - Solution:  
+    Use regular `ast.Name` variables. Or tuple of `ast.Name` variables.
     Star names are also fine.
 
-Example::
+Example:
 
     # Correct:
     with open('README.md') as readme:
         ...
-
+    
     # Wrong:
     with open('README.md') as files['readme']:
         ...
 
-.. versionadded:: 0.8.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.8.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS407.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS407.md
@@ -3,30 +3,38 @@ code: 407
 title: Found mutable module constant
 ---
 
-
 Forbid mutable constants on a module level.
 
-Reasoning:
+  - Reasoning:  
     Constants should be immutable.
 
-Solution:
+  - Solution:  
     Use immutable types for constants.
 
-We only treat ``ast.Set``, ``ast.Dict``, ``ast.List`` and comprehensions
-as mutable things. All other nodes are still fine.
+We only treat `ast.Set`, `ast.Dict`, `ast.List` and comprehensions as
+mutable things. All other nodes are still fine.
 
-Example::
+Example:
 
     # Correct:
     import types
     CONST1 = frozenset((1, 2, 3))
     CONST2 = (1, 2, 3)
     CONST3 = types.MappingProxyType({'key': 'value'})
-
+    
     # Wrong:
     CONST1 = {1, 2, 3}
     CONST2 = [x for x in some()]
     CONST3 = {'key': 'value'}
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS408.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS408.md
@@ -3,27 +3,40 @@ code: 408
 title: Found duplicate logical condition
 ---
 
-
 Forbid using the same logical conditions in one expression.
 
-Reasoning:
-    Using the same name in a logical condition more than once
-    indicates that you are either making a logical mistake,
-    or just over-complicating your design.
+  - Reasoning:  
+    Using the same name in a logical condition more than once indicates
+    that you are either making a logical mistake, or just
+    over-complicating your design.
 
-Solution:
+  - Solution:  
     Remove the duplicated condition.
 
-Example::
+Example:
 
     # Correct:
     if some_value or other_value:
         ...
-
+    
     # Wrong:
     if some_value or some_value:
         ...
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.13.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS409.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS409.md
@@ -3,34 +3,41 @@ code: 409
 title: Found heterogeneous compare
 ---
 
-
 Forbid heterogeneous operators in one comparison.
 
-Note, that we do allow mixing  ``>`` with ``>=``
-and ``<`` with ``<=`` operators.
+Note, that we do allow mixing `>` with `>=` and `<` with `<=` operators.
 
-Reasoning:
+  - Reasoning:  
     This is hard to read and understand.
 
-Solution:
-    Refactor the expression to have separate parts
-    joined with ``and`` boolean operator.
+  - Solution:  
+    Refactor the expression to have separate parts joined with `and`
+    boolean operator.
 
-Example::
+Example:
 
     # Correct:
     if x == y == z:
         ...
-
+    
     if x > y >= z:
         ...
-
+    
     # Wrong:
     if x > y == 5:
         ...
-
+    
     if x == y != z:
         ...
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS410.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS410.md
@@ -3,28 +3,30 @@ code: 410
 title: 'Found wrong metadata variable: {0}'
 ---
 
-
 Forbid some module-level variables.
 
-Reasoning:
-    We discourage using module variables like ``__author__``,
-    because code should not contain any metadata.
+  - Reasoning:  
+    We discourage using module variables like `__author__`, because code
+    should not contain any metadata.
 
-Solution:
-    Place all the metadata in ``setup.py``,
-    ``setup.cfg``, or ``pyproject.toml``.
-    Use proper docstrings and packaging classifiers.
-    Use ``importlib.metadata`` (or ``importlib_metadata`` on python < 3.8)
+  - Solution:  
+    Place all the metadata in `setup.py`, `setup.cfg`, or
+    `pyproject.toml`. Use proper docstrings and packaging classifiers.
+    Use `importlib.metadata` (or `importlib_metadata` on python \< 3.8)
     if you need to import this data into your app.
 
 See
-:py:data:`~wemake_python_styleguide.constants.MODULE_METADATA_VARIABLES_BLACKLIST`
+:py`~wemake_python_styleguide.constants.MODULE_METADATA_VARIABLES_BLACKLIST`
 for full list of bad names.
 
-Example::
+Example:
 
     # Wrong:
     __author__ = 'Nikita Sobolev'
     __version__ = 0.1.2
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS411.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS411.md
@@ -3,16 +3,20 @@ code: 411
 title: Found empty module
 ---
 
-
 Forbid empty modules.
 
-Reasoning:
+  - Reasoning:  
     Why is it even there? Do not pollute your project with empty files.
 
-Solution:
+  - Solution:  
     If you have an empty module there are two ways to handle that:
+    
+    1.  delete it
+    2.  drop some documentation in it, so you will explain why it is
+        there
 
-    1. delete it
-    2. drop some documentation in it, so you will explain why it is there
+<div class="versionadded">
 
-.. versionadded:: 0.1.0
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS412.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS412.md
@@ -3,37 +3,39 @@ code: 412
 title: Found `__init__.py` module with logic
 ---
 
+Forbid logic inside `__init__` module.
 
-Forbid logic inside ``__init__`` module.
+  - Reasoning:  
+    If you have logic inside the `__init__` module It means several
+    things:
+    
+    1.  you are keeping some outdated stuff there, you need to refactor
+    2.  you are placing this logic in the wrong file, just create
+        another one
+    3.  you are doing some dark magic, and you should not do that
 
-Reasoning:
-    If you have logic inside the ``__init__`` module
-    It means several things:
-
-    1. you are keeping some outdated stuff there, you need to refactor
-    2. you are placing this logic in the wrong file,
-       just create another one
-    3. you are doing some dark magic, and you should not do that
-
-Solution:
+  - Solution:  
     Put your code in other modules.
 
-However, we allow some contents inside the ``__init__`` module:
+However, we allow some contents inside the `__init__` module:
 
-1. comments, since they are dropped before AST comes in play
-2. docstrings are used sometimes when required to state something
+1.  comments, since they are dropped before AST comes in play
+2.  docstrings are used sometimes when required to state something
 
-It is also fine when you have different users that use your code.
-And you do not want to break everything for them.
-In this case, this rule can be configured.
+It is also fine when you have different users that use your code. And
+you do not want to break everything for them. In this case, this rule
+can be configured.
 
-Configuration:
-    This rule is configurable with ``--i-control-code``
-    and ``--i-dont-control-code``.
-    Default:
-    :str:`wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
+  - Configuration:  
+    This rule is configurable with `--i-control-code` and
+    `--i-dont-control-code`. Default:
+    `wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
 
-When using ``--i-dont-control-code`` it is still recommended
-to only have imports in your ``__init__.py``.
+When using `--i-dont-control-code` it is still recommended to only have
+imports in your `__init__.py`.
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS412.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS412.md
@@ -29,7 +29,7 @@ can be configured.
   - Configuration:  
     This rule is configurable with `--i-control-code` and
     `--i-dont-control-code`. Default:
-    `wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
+    `python://wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
 
 When using `--i-dont-control-code` it is still recommended to only have
 imports in your `__init__.py`.

--- a/docs/wemake-python-styleguide/0.15.2/WPS413.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS413.md
@@ -17,7 +17,7 @@ Forbid `__getattr__` and `__dir__` module magic methods.
     `--i-dont-control-code`.
 
   - Default:  
-    `wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
+    `python://wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS413.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS413.md
@@ -3,20 +3,24 @@ code: 413
 title: 'Found bad magic module function: {0}'
 ---
 
+Forbid `__getattr__` and `__dir__` module magic methods.
 
-Forbid ``__getattr__`` and ``__dir__`` module magic methods.
+  - Reasoning:  
+    It does not bring any features, only making it harder to understand
+    what is going on.
 
-Reasoning:
-    It does not bring any features,
-    only making it harder to understand what is going on.
-
-Solution:
+  - Solution:  
     Refactor your code to use custom methods instead.
 
-Configuration:
-    This rule is configurable with ``--i-control-code``
-    and ``--i-dont-control-code``.
-Default:
-    :str:`wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
+  - Configuration:  
+    This rule is configurable with `--i-control-code` and
+    `--i-dont-control-code`.
 
-.. versionadded:: 0.9.0
+  - Default:  
+    `wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
+
+<div class="versionadded">
+
+0.9.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS414.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS414.md
@@ -3,30 +3,39 @@ code: 414
 title: Found incorrect unpacking target
 ---
 
-
 Forbid tuple unpacking with side-effects.
 
-Reasoning:
-    Having unpacking with side-effects is very dirty.
-    You might get in serious and very hard-to-debug troubles because of
-    this technique so do not use it.
-
+  - Reasoning:  
+    Having unpacking with side-effects is very dirty. You might get in
+    serious and very hard-to-debug troubles because of this technique so
+    do not use it.
+    
     This includes assigning to attributes, as this results in modifying
-    the instance. Every modification should be explicit on it's own line.
+    the instance. Every modification should be explicit on it's own
+    line.
 
-Solution:
+  - Solution:  
     Use unpacking only with variables, not any other entities.
 
-Example::
+Example:
 
     # Correct:
     reader, writter = call()
     self.reader = reader
     self.writer = writer
-
+    
     # Wrong:
     first, some_dict['alias'] = some()
     self.reader, self.writer = call()
 
-.. versionadded:: 0.6.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.6.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS415.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS415.md
@@ -3,25 +3,24 @@ code: 415
 title: 'Found duplicate exception: {0}'
 ---
 
+Forbid the same exception class in multiple `except` blocks.
 
-Forbid the same exception class in multiple ``except`` blocks.
+  - Reasoning:  
+    Having the same exception name in different blocks means that
+    something is not right: since only one branch will work. Another one
+    will always be ignored. So, that is an error.
 
-Reasoning:
-    Having the same exception name in different blocks means
-    that something is not right: since only one branch will work.
-    Another one will always be ignored. So, that is an error.
-
-Solution:
+  - Solution:  
     Use unique exception handling rules.
 
-Example::
+Example:
 
     # Correct:
     try:
         ...
     except ValueError:
         ...
-
+    
     # Wrong:
     try:
         ...
@@ -30,5 +29,14 @@ Example::
     except ValueError:
         ...
 
-.. versionadded:: 0.6.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.6.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS416.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS416.md
@@ -3,31 +3,39 @@ code: 416
 title: Found `yield` inside comprehension
 ---
 
+Forbid `yield` keyword inside comprehensions.
 
-Forbid ``yield`` keyword inside comprehensions.
+This is a `SyntaxError` starting from `python3.8`.
 
-This is a ``SyntaxError`` starting from ``python3.8``.
+  - Reasoning:  
+    Having the `yield` keyword inside comprehensions is error-prone. You
+    can shoot yourself in the foot by an inaccurate usage of this
+    feature.
 
-Reasoning:
-    Having the ``yield`` keyword inside comprehensions is error-prone.
-    You can shoot yourself in the foot by
-    an inaccurate usage of this feature.
+  - Solution:  
+    Use regular `for` loops with `yield` keywords or create a separate
+    generator function.
 
-Solution:
-    Use regular ``for`` loops with ``yield`` keywords
-    or create a separate generator function.
-
-Example::
+Example:
 
     # Wrong:
     list((yield letter) for letter in 'ab')
     # Will resilt in: ['a', None, 'b', None]
-
+    
     list([(yield letter) for letter in 'ab'])
     # Will result in: ['a', 'b']
 
-See also:
-    https://github.com/satwikkansal/wtfPython#-yielding-none
+  - See also:  
+    <https://github.com/satwikkansal/wtfPython#-yielding-none>
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS417.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS417.md
@@ -3,35 +3,47 @@ code: 417
 title: 'Found non-unique item in hash: {0}'
 ---
 
-
 Forbid duplicate items in hashes.
 
-Reasoning:
-    When you explicitly put duplicate items
-    in ``set`` literals or in ``dict`` keys
-    it just does not make any sense since hashes cannot contain
-    duplicate items and they will be removed anyway.
+  - Reasoning:  
+    When you explicitly put duplicate items in `set` literals or in
+    `dict` keys it just does not make any sense since hashes cannot
+    contain duplicate items and they will be removed anyway.
 
-Solution:
+  - Solution:  
     Remove duplicate items.
 
-Example::
+Example:
 
     # Correct:
     some_set = {'a', variable1}
     some_set = {make_call(), make_call()}
-
+    
     # Wrong:
     some_set = {'a', 'a', variable1, variable1}
 
-Things that we consider duplicates: builtins and variables.
-These nodes are not checked because they may return different results:
+Things that we consider duplicates: builtins and variables. These nodes
+are not checked because they may return different results:
 
-- function and method calls
-- comprehensions
-- attributes
-- subscribe operations
+  - function and method calls
+  - comprehensions
+  - attributes
+  - subscribe operations
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS418.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS418.md
@@ -3,30 +3,37 @@ code: 418
 title: Found exception inherited from `BaseException`
 ---
 
+Forbid exceptions inherited from `BaseException`.
 
-Forbid exceptions inherited from ``BaseException``.
+  - Reasoning:  
+    `BaseException` is a special case: it is not designed to be extended
+    by users. A lot of your `except Exception` cases won't work. That's
+    incorrect and dangerous.
 
-Reasoning:
-    ``BaseException`` is a special case:
-    it is not designed to be extended by users.
-    A lot of your ``except Exception`` cases won't work.
-    That's incorrect and dangerous.
+  - Solution:  
+    Change the base class to `Exception`.
 
-Solution:
-    Change the base class to ``Exception``.
-
-Example::
+Example:
 
     # Correct:
     class MyException(Exception):
         ...
-
+    
     # Wrong:
     class MyException(BaseException):
         ...
 
-See also:
-    https://docs.python.org/3/library/exceptions.html#exception-hierarchy
+  - See also:  
+    <https://docs.python.org/3/library/exceptions.html#exception-hierarchy>
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS419.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS419.md
@@ -3,25 +3,23 @@ code: 419
 title: Found `try`/`else`/`finally` with multiple return paths
 ---
 
+Forbid multiple returning paths with `try` / `except` case.
 
-Forbid multiple returning paths with ``try`` / ``except`` case.
+Note, that we check for any `return`, `break`, or `raise` nodes.
 
-Note, that we check for any ``return``, ``break``, or ``raise`` nodes.
+  - Reasoning:  
+    The problem with `return` in `else` and `finally` is that it is
+    impossible to say what value is going to be returned without looking
+    up the implementation details. Why? Because `return` does not expect
+    that some other code will be executed after it. But, `finally` is
+    always executed, even after `return`. And `else` will not be
+    executed when there are no exceptions in `try` case and a `return`
+    statement.
 
-Reasoning:
-    The problem with ``return`` in ``else`` and ``finally``
-    is that it is impossible to say what value is going to be
-    returned without looking up the implementation details. Why?
-    Because ``return`` does not expect
-    that some other code will be executed after it.
-    But, ``finally`` is always executed, even after ``return``.
-    And ``else`` will not be executed when there are no exceptions
-    in ``try`` case and a ``return`` statement.
+  - Solution:  
+    Remove `return` from one of the cases.
 
-Solution:
-    Remove ``return`` from one of the cases.
-
-Example::
+Example:
 
     # Correct:
     try:
@@ -30,7 +28,7 @@ Example::
         ...
     finally:
         clear_things_up()
-
+    
     # Wrong:
     try:
         return 1  # this line will never return
@@ -38,7 +36,7 @@ Example::
         ...
     finally:
         return 2  # this line will actually return
-
+    
     try:
         return 1  # this line will actually return
     except ZeroDivisionError:
@@ -46,6 +44,20 @@ Example::
     else:
         return 0  # this line will never return
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS420.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS420.md
@@ -3,30 +3,32 @@ code: 420
 title: 'Found wrong keyword: {0}'
 ---
 
+Forbid some `python` keywords.
 
-Forbid some ``python`` keywords.
-
-Reasoning:
+  - Reasoning:  
     Using some keywords generally causes more pain than it relieves.
+    
+    `del` keyword is not composable with other functions, you cannot
+    pass it as a regular function. It is also quite error-prone due to
+    `__del__` magic method complexity and that `del` is actually used to
+    nullify variables and delete them from the execution scope.
+    Moreover, it has a lot of substitutions. You won't miss it\!
+    
+    `pass` keyword is just useless by design. There's no use-case for
+    it. Because it does literally nothing.
+    
+    `global` and `nonlocal` promote bad-practices of having an external
+    mutable state somewhere. This solution does not scale and leads to
+    multiple possible mistakes in the future.
 
-    ``del`` keyword is not composable with other functions,
-    you cannot pass it as a regular function.
-    It is also quite error-prone due to ``__del__`` magic method complexity
-    and that ``del`` is actually used to nullify variables and delete them
-    from the execution scope.
-    Moreover, it has a lot of substitutions. You won't miss it!
+  - Solution:  
+    Solutions differ from keyword to keyword. `pass` should be replaced
+    with docstring or `contextlib.suppress`. `del` should be replaced
+    with specialized methods like `.pop()`. `global` and `nonlocal`
+    usages should be refactored.
 
-    ``pass`` keyword is just useless by design. There's no use-case for it.
-    Because it does literally nothing.
+<div class="versionadded">
 
-    ``global`` and ``nonlocal`` promote bad-practices of having an external
-    mutable state somewhere. This solution does not scale
-    and leads to multiple possible mistakes in the future.
+0.1.0
 
-Solution:
-    Solutions differ from keyword to keyword.
-    ``pass`` should be replaced with docstring or ``contextlib.suppress``.
-    ``del`` should be replaced with specialized methods like ``.pop()``.
-    ``global`` and ``nonlocal`` usages should be refactored.
-
-.. versionadded:: 0.1.0
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS421.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS421.md
@@ -3,19 +3,20 @@ code: 421
 title: 'Found wrong function call: {0}'
 ---
 
-
 Forbid calling some built-in functions.
 
-Reasoning:
-    Some functions are only suitable
-    for very specific use cases,
-    we forbid the use of them in a free manner.
+  - Reasoning:  
+    Some functions are only suitable for very specific use cases, we
+    forbid the use of them in a free manner.
 
-See
-:py:data:`~wemake_python_styleguide.constants.FUNCTIONS_BLACKLIST`
-for the full list of blacklisted functions.
+See :py`~wemake_python_styleguide.constants.FUNCTIONS_BLACKLIST` for the
+full list of blacklisted functions.
 
-See also:
-    https://www.youtube.com/watch?v=YjHsOrOOSuI
+  - See also:  
+    <https://www.youtube.com/watch?v=YjHsOrOOSuI>
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS422.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS422.md
@@ -3,27 +3,29 @@ code: 422
 title: 'Found future import: {0}'
 ---
 
+Forbid `__future__` imports.
 
-Forbid ``__future__`` imports.
-
-Reasoning:
-    Almost all ``__future__`` imports are legacy ``python2`` compatibility
+  - Reasoning:  
+    Almost all `__future__` imports are legacy `python2` compatibility
     tools that are no longer required.
 
-Solution:
-    Remove them. Drop ``python2`` support.
+  - Solution:  
+    Remove them. Drop `python2` support.
 
-Except, there are some new ones for ``python4`` support.
-See
-:py:data:`~wemake_python_styleguide.constants.FUTURE_IMPORTS_WHITELIST`
-for the full list of allowed future imports.
+Except, there are some new ones for `python4` support. See
+:py`~wemake_python_styleguide.constants.FUTURE_IMPORTS_WHITELIST` for
+the full list of allowed future imports.
 
-Example::
+Example:
 
     # Correct:
     from __future__ import annotations
-
+    
     # Wrong:
     from __future__ import print_function
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS423.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS423.md
@@ -3,27 +3,29 @@ code: 423
 title: Found raise NotImplemented
 ---
 
+Forbid `NotImplemented` exception.
 
-Forbid ``NotImplemented`` exception.
+  - Reasoning:  
+    `NotImplemented` and `NotImplementedError` look similar but they
+    have different use cases. Use cases of `NotImplemented` are too
+    limited to be generally available.
 
-Reasoning:
-    ``NotImplemented`` and ``NotImplementedError`` look similar
-    but they have different use cases.
-    Use cases of ``NotImplemented`` are too limited
-    to be generally available.
+  - Solution:  
+    Use `NotImplementedError`.
 
-Solution:
-    Use ``NotImplementedError``.
-
-Example::
+Example:
 
     # Correct:
     raise NotImplementedError('To be done')
-
+    
     # Wrong:
     raise NotImplemented
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
 
-See also:
-    https://stackoverflow.com/a/44575926/4842742
+0.1.0
+
+</div>
+
+  - See also:  
+    <https://stackoverflow.com/a/44575926/4842742>

--- a/docs/wemake-python-styleguide/0.15.2/WPS424.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS424.md
@@ -3,29 +3,30 @@ code: 424
 title: Found except `BaseException`
 ---
 
+Forbid `BaseException` exception.
 
-Forbid ``BaseException`` exception.
+  - Reasoning:  
+    We can silence system exit and keyboard interrupt with this
+    exception handler. It is almost the same as raw `except:` block.
 
-Reasoning:
-    We can silence system exit and keyboard interrupt
-    with this exception handler.
-    It is almost the same as raw ``except:`` block.
+  - Solution:  
+    Handle `Exception`, `KeyboardInterrupt`, `GeneratorExit`, and
+    `SystemExit` separately. Do not use the plain `except:` keyword.
 
-Solution:
-    Handle ``Exception``, ``KeyboardInterrupt``,
-    ``GeneratorExit``, and ``SystemExit`` separately.
-    Do not use the plain ``except:`` keyword.
-
-Example::
+Example:
 
     # Correct:
     except Exception as ex: ...
-
+    
     # Wrong:
     except BaseException as ex: ...
 
-.. versionadded:: 0.3.0
+<div class="versionadded">
 
-See also:
-    https://docs.python.org/3/library/exceptions.html#exception-hierarchy
-    https://help.semmle.com/wiki/pages/viewpage.action?pageId=1608527
+0.3.0
+
+</div>
+
+  - See also:  
+    <https://docs.python.org/3/library/exceptions.html#exception-hierarchy>
+    <https://help.semmle.com/wiki/pages/viewpage.action?pageId=1608527>

--- a/docs/wemake-python-styleguide/0.15.2/WPS425.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS425.md
@@ -3,30 +3,31 @@ code: 425
 title: 'Found boolean non-keyword argument: {0}'
 ---
 
-
 Forbid booleans as non-keyword parameters.
 
-Reasoning:
-    Passing booleans as regular positional parameters
-    is very non-descriptive.
-    It is almost impossible to tell what this
-    parameter means and you almost always have to look up the implementation
-    to tell what is going on.
-    The only exception from this rule is passing a boolean as a
-    non-keyword argument when it is the only passed argument.
+  - Reasoning:  
+    Passing booleans as regular positional parameters is very
+    non-descriptive. It is almost impossible to tell what this parameter
+    means and you almost always have to look up the implementation to
+    tell what is going on. The only exception from this rule is passing
+    a boolean as a non-keyword argument when it is the only passed
+    argument.
 
+  - Solution:  
+    Pass booleans as keywords only. This will help you to save extra
+    context on what's going on.
 
-Solution:
-    Pass booleans as keywords only.
-    This will help you to save extra context on what's going on.
-
-Example::
+Example:
 
     # Correct:
     UserRepository.update(True)
     UsersRepository.add(user, cache=True)
-
+    
     # Wrong:
     UsersRepository.add(user, True)
 
-.. versionadded:: 0.6.0
+<div class="versionadded">
+
+0.6.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS426.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS426.md
@@ -3,34 +3,47 @@ code: 426
 title: Found `lambda` in loop's body
 ---
 
+Forbid `lambda` inside loops.
 
-Forbid ``lambda`` inside loops.
+We check `while`, `for`, and `async for` loop bodies. We also check
+comprehension value parts.
 
-We check ``while``, ``for``, and ``async for`` loop bodies.
-We also check comprehension value parts.
+  - Reasoning:  
+    It is error-prone to use `lambda` inside `for` and `while` loops due
+    to the famous late-binding.
 
-Reasoning:
-    It is error-prone to use ``lambda`` inside
-    ``for`` and ``while`` loops due to the famous late-binding.
-
-Solution:
-    Use regular functions, factory functions, or ``partial`` functions.
+  - Solution:  
+    Use regular functions, factory functions, or `partial` functions.
     Save yourself from possible confusion.
 
-Example::
+Example:
 
     # Correct:
     for index in range(10):
         some.append(partial_function(index))
-
+    
     # Wrong:
     for index in range(10):
         some.append(lambda index=index: index * 10))
         other.append(lambda: index * 10))
 
-.. versionadded:: 0.5.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
 
-See also:
-    https://docs.python-guide.org/writing/gotchas/#late-binding-closures
+0.5.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>
+
+  - See also:  
+    <https://docs.python-guide.org/writing/gotchas/#late-binding-closures>

--- a/docs/wemake-python-styleguide/0.15.2/WPS427.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS427.md
@@ -3,39 +3,46 @@ code: 427
 title: Found unreachable code
 ---
 
-
 Forbid unreachable code.
 
-What is unreachable code? It is some lines of code that
-cannot be executed by python's interpreter.
+What is unreachable code? It is some lines of code that cannot be
+executed by python's interpreter.
 
-This is probably caused by ``return`` or ``raise`` statements.
-However, we cannot cover 100% of truly unreachable code by this rule.
-This happens due to the dynamic nature of python.
-For example, detecting that ``1 / some_value`` would sometimes raise
-an exception is too complicated and is out of the scope of this rule.
+This is probably caused by `return` or `raise` statements. However, we
+cannot cover 100% of truly unreachable code by this rule. This happens
+due to the dynamic nature of python. For example, detecting that `1 /
+some_value` would sometimes raise an exception is too complicated and is
+out of the scope of this rule.
 
-Reasoning:
-    Having dead code in your project is an indicator that
-    you do not care about your codebase at all.
-    It dramatically reduces code quality and readability.
-    It also demotivates team members.
+  - Reasoning:  
+    Having dead code in your project is an indicator that you do not
+    care about your codebase at all. It dramatically reduces code
+    quality and readability. It also demotivates team members.
 
-Solution:
-    Delete any unreachable code you have or refactor it,
-    if this happens by your mistake.
+  - Solution:  
+    Delete any unreachable code you have or refactor it, if this happens
+    by your mistake.
 
-Example::
+Example:
 
     # Correct:
     def some_function():
         print('This line is reachable, all good')
         return 5
-
+    
     # Wrong:
     def some_function():
         return 5
         print('This line is unreachable')
 
-.. versionadded:: 0.5.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.5.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS428.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS428.md
@@ -3,30 +3,37 @@ code: 428
 title: Found statement that has no effect
 ---
 
-
 Forbid statements that do nothing.
 
-Reasoning:
-    Statements that just access the value or expressions
-    used as statements indicate that your code
-    contains deadlines.
-    They just pollute your codebase and do nothing.
+  - Reasoning:  
+    Statements that just access the value or expressions used as
+    statements indicate that your code contains deadlines. They just
+    pollute your codebase and do nothing.
 
-Solution:
-    Refactor your code in case it was a typo or error
-    or just delete this code.
+  - Solution:  
+    Refactor your code in case it was a typo or error or just delete
+    this code.
 
-Example::
+Example:
 
     # Correct:
     def some_function():
         price = 8 + 2
         return price
-
+    
     # Wrong:
     def some_function():
         8 + 2
         print
 
-.. versionadded:: 0.5.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.5.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS429.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS429.md
@@ -3,25 +3,33 @@ code: 429
 title: Found multiple assign targets
 ---
 
-
 Forbid multiple assignments on the same line.
 
-Reasoning:
+  - Reasoning:  
     Multiple assignments on the same line might not do what you think
-    they do. They can also grow pretty long and you might not notice
-    the rising complexity of your code.
+    they do. They can also grow pretty long and you might not notice the
+    rising complexity of your code.
 
-Solution:
+  - Solution:  
     Use separate lines for each assignment.
 
-Example::
+Example:
 
     # Correct:
     a = 1
     b = 1
-
+    
     # Wrong:
     a = b = 1
 
-.. versionadded:: 0.6.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.6.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS430.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS430.md
@@ -3,34 +3,36 @@ code: 430
 title: 'Found nested function: {0}'
 ---
 
-
 Forbid nested functions.
 
-Reasoning:
-    Nesting functions is bad practice.
-    It is hard to test them and it is hard to separate them later.
-    People tend to overuse closures, so it's hard to manage the dataflow.
+  - Reasoning:  
+    Nesting functions is bad practice. It is hard to test them and it is
+    hard to separate them later. People tend to overuse closures, so
+    it's hard to manage the dataflow.
 
-Solution:
-    Just write flat functions, there's no need to nest them.
-    Pass parameters as normal arguments, do not use closures
-    until you need them for decorators or factories.
+  - Solution:  
+    Just write flat functions, there's no need to nest them. Pass
+    parameters as normal arguments, do not use closures until you need
+    them for decorators or factories.
 
-We also forbid nesting ``lambda`` and ``async`` functions.
+We also forbid nesting `lambda` and `async` functions.
 
-See
-:py:data:`~wemake_python_styleguide.constants.NESTED_FUNCTIONS_WHITELIST`
+See :py`~wemake_python_styleguide.constants.NESTED_FUNCTIONS_WHITELIST`
 for the whole list of whitelisted names.
 
-Example::
+Example:
 
     # Correct:
     def do_some(): ...
     def other(): ...
-
+    
     # Wrong:
     def do_some():
         def inner():
             ...
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
+
+0.1.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS431.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS431.md
@@ -3,34 +3,42 @@ code: 431
 title: 'Found nested class: {0}'
 ---
 
-
 Forbid nested classes.
 
-Reasoning:
-    Nested classes are really hard to manage.
-    You cannot even create an instance of this class in many cases.
-    Testing them is also really hard.
+  - Reasoning:  
+    Nested classes are really hard to manage. You cannot even create an
+    instance of this class in many cases. Testing them is also really
+    hard.
 
-Solution:
-    Just write flat classes, there's no need to nest them.
-    If you are nesting classes inside a function for parametrization,
-    then you will probably need to use a different design (or metaclasses).
+  - Solution:  
+    Just write flat classes, there's no need to nest them. If you are
+    nesting classes inside a function for parametrization, then you will
+    probably need to use a different design (or metaclasses).
 
-Configuration:
-    This rule is configurable with ``--nested-classes-whitelist``.
+  - Configuration:  
+    This rule is configurable with `--nested-classes-whitelist`.
     Default:
-    :str:`wemake_python_styleguide.options.defaults.NESTED_CLASSES_WHITELIST`
+    `wemake_python_styleguide.options.defaults.NESTED_CLASSES_WHITELIST`
 
-Example::
+Example:
 
     # Correct:
     class Some(object): ...
     class Other(object): ...
-
+    
     # Wrong:
     class Some(object):
         class Inner(object):
             ...
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.13.0
+<div class="versionadded">
+
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS431.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS431.md
@@ -18,7 +18,7 @@ Forbid nested classes.
   - Configuration:  
     This rule is configurable with `--nested-classes-whitelist`.
     Default:
-    `wemake_python_styleguide.options.defaults.NESTED_CLASSES_WHITELIST`
+    `python://wemake_python_styleguide.options.defaults.NESTED_CLASSES_WHITELIST`
 
 Example:
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS432.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS432.md
@@ -3,39 +3,40 @@ code: 432
 title: 'Found magic number: {0}'
 ---
 
-
 Forbid magic numbers.
 
 What do we call a "magic number"? Well, it is actually any number that
-appears in your code out of nowhere. Like ``42``. Or ``0.32``.
+appears in your code out of nowhere. Like `42`. Or `0.32`.
 
-Reasoning:
-    It is very hard to remember what these numbers mean.
-    Why were they used? Should they ever be changed?
-    Or are they eternal like ``3.14``?
+  - Reasoning:  
+    It is very hard to remember what these numbers mean. Why were they
+    used? Should they ever be changed? Or are they eternal like `3.14`?
 
-Solution:
-    Give these numbers a name! Move them to a separate variable,
-    giving more context to the reader. And by moving things into new
-    variables you will trigger other complexity checks.
+  - Solution:  
+    Give these numbers a name\! Move them to a separate variable, giving
+    more context to the reader. And by moving things into new variables
+    you will trigger other complexity checks.
 
-Example::
+Example:
 
     # Correct:
     price_in_euro = 3.33  # could be changed later
     total = get_items_from_cart() * price_in_euro
-
+    
     # Wrong:
     total = get_items_from_cart() * 3.33
 
-What are the numbers that we exclude from this check?
-Any numbers that are assigned to a variable, array, dictionary,
-or keyword arguments inside a function.
-``int`` numbers that are in range ``[-10, 10]`` and
-some other common numbers, that are defined in
-:py:data:`~wemake_python_styleguide.constants.MAGIC_NUMBERS_WHITELIST`
+What are the numbers that we exclude from this check? Any numbers that
+are assigned to a variable, array, dictionary, or keyword arguments
+inside a function. `int` numbers that are in range `[-10, 10]` and some
+other common numbers, that are defined in
+:py`~wemake_python_styleguide.constants.MAGIC_NUMBERS_WHITELIST`
 
-.. versionadded:: 0.1.0
+<div class="versionadded">
 
-See also:
-    https://en.wikipedia.org/wiki/Magic_number_(programming)
+0.1.0
+
+</div>
+
+  - See also:  
+    <https://en.wikipedia.org/wiki/Magic_number_(programming)>

--- a/docs/wemake-python-styleguide/0.15.2/WPS433.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS433.md
@@ -3,31 +3,39 @@ code: 433
 title: Found nested import
 ---
 
-
 Forbid imports nested in functions.
 
-Reasoning:
-    Usually, nested imports are used to fix the import cycle.
-    So, nested imports show that there's an issue with your design.
+  - Reasoning:  
+    Usually, nested imports are used to fix the import cycle. So, nested
+    imports show that there's an issue with your design.
 
-Solution:
+  - Solution:  
     You don't need nested imports, you need to refactor your code.
-    Introduce a new module or find another way to do what you want to do.
-    Rethink how your layered architecture should look.
+    Introduce a new module or find another way to do what you want to
+    do. Rethink how your layered architecture should look.
 
-Example::
+Example:
 
     # Correct:
     from my_module import some_function
-
+    
     def some(): ...
-
+    
     # Wrong:
     def some():
         from my_module import some_function
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
 
-See also:
-    https://github.com/seddonym/layer_linter
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+  - See also:  
+    <https://github.com/seddonym/layer_linter>

--- a/docs/wemake-python-styleguide/0.15.2/WPS434.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS434.md
@@ -3,22 +3,30 @@ code: 434
 title: 'Found reassigning variable to itself: {0}'
 ---
 
-
 Forbid assigning a variable to itself.
 
-Reasoning:
-    There is no need to do that.
-    Generally, it is an indication of some errors or just dead code.
+  - Reasoning:  
+    There is no need to do that. Generally, it is an indication of some
+    errors or just dead code.
 
-Example::
+Example:
 
     # Correct:
     some = some + 1
     x_coord, y_coord = y_coord, x_coord
-
+    
     # Wrong:
     some = some
     x_coord, y_coord = x_coord, y_coord
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS435.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS435.md
@@ -3,23 +3,26 @@ code: 435
 title: Found list multiply
 ---
 
-
 Forbid multiplying lists.
 
-Reasoning:
-    When you multiply lists - it does not create new values,
-    it creates references to the existing value.
-    It is not what people mean in 99.9% of cases.
+  - Reasoning:  
+    When you multiply lists - it does not create new values, it creates
+    references to the existing value. It is not what people mean in
+    99.9% of cases.
 
-Solution:
+  - Solution:  
     Use list comprehension or loop instead.
 
-Example::
+Example:
 
     # Wrong:
     my_list = [1, 2, 3] * 3
 
-See also:
-    https://github.com/satwikkansal/wtfPython#-explanation-8
+  - See also:  
+    <https://github.com/satwikkansal/wtfPython#-explanation-8>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS436.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS436.md
@@ -3,31 +3,42 @@ code: 436
 title: 'Found protected module import: {0}'
 ---
 
-
 Forbid importing protected modules.
 
-Related to :class:`~ProtectedModuleMemberViolation`.
+Related to `~ProtectedModuleMemberViolation`.
 
-Reasoning:
-    When importing protected modules we break a contract
-    that authors of this module enforce.
-    This way we are not respecting encapsulation and it may break
-    our code at any moment.
+  - Reasoning:  
+    When importing protected modules we break a contract that authors of
+    this module enforce. This way we are not respecting encapsulation
+    and it may break our code at any moment.
 
-Solution:
-    Do not import protected modules.
-    Respect the encapsulation.
+  - Solution:  
+    Do not import protected modules. Respect the encapsulation.
 
-Example::
+Example:
 
     # Correct:
     import public_module
     from some.public.module import FooClass
-
+    
     # Wrong:
     import _compat
     from some._protected.module import BarClass
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS437.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS437.md
@@ -3,37 +3,43 @@ code: 437
 title: 'Found protected attribute usage: {0}'
 ---
 
-
 Forbid protected attributes and methods.
 
-Reasoning:
-    When using protected attributes and method we break a contract
-    that authors of this class enforce.
-    This way we are not respecting encapsulation and it may break
-    our code at any moment.
+  - Reasoning:  
+    When using protected attributes and method we break a contract that
+    authors of this class enforce. This way we are not respecting
+    encapsulation and it may break our code at any moment.
 
-Solution:
-    Do not use protected attributes and methods.
-    Respect the encapsulation.
+  - Solution:  
+    Do not use protected attributes and methods. Respect the
+    encapsulation.
 
-Example::
+Example:
 
     # Correct:
     self._protected = 1
     cls._hidden_method()
     some.public()
     super()._protected()
-
+    
     # Wrong:
     print(some._protected)
     instance._hidden()
     self.container._internal = 10
 
-Note, that it is possible to use protected attributes with
-``self``, ``cls``, and ``super()`` as base names.
-We allow this so you can create and
-use protected attributes and methods inside the class context.
-This is how protected attributes should be used.
+Note, that it is possible to use protected attributes with `self`,
+`cls`, and `super()` as base names. We allow this so you can create and
+use protected attributes and methods inside the class context. This is
+how protected attributes should be used.
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS438.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS438.md
@@ -3,30 +3,33 @@ code: 438
 title: Found `StopIteration` raising inside generator
 ---
 
+Forbid raising `StopIteration` inside generators.
 
-Forbid raising ``StopIteration`` inside generators.
+  - Reasoning:  
+    `StopIteration` should not be raised explicitly in generators.
 
-Reasoning:
-    ``StopIteration`` should not be raised explicitly in generators.
-
-Solution:
+  - Solution:  
     Use a return statement to get out of a generator.
 
-Example::
+Example:
 
     # Correct:
     def some_generator():
         if some_value:
             return
         yield 1
-
+    
     # Wrong:
     def some_generator():
         if some_value:
             raise StopIteration
         yield 1
 
-See also:
-    https://docs.python.org/3/library/exceptions.html#StopIteration
+  - See also:  
+    <https://docs.python.org/3/library/exceptions.html#StopIteration>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS439.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS439.md
@@ -3,23 +3,25 @@ code: 439
 title: 'Found unicode escape in a binary string: {0}'
 ---
 
-
 Forbid Unicode escape sequences in binary strings.
 
-Reasoning:
-    Binary strings do not work with Unicode.
-    Having Unicode escape characters in there means
-    that you have an error in your code.
+  - Reasoning:  
+    Binary strings do not work with Unicode. Having Unicode escape
+    characters in there means that you have an error in your code.
 
-Solution:
+  - Solution:  
     Use regular strings when escaping Unicode strings.
 
-Example::
+Example:
 
     # Correct:
     escaped = '\u0041'  # equals to 'A'
-
+    
     # Wrong:
     escaped = b'\u0040'  # equals to b'\\u0040'
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS440.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS440.md
@@ -3,36 +3,39 @@ code: 440
 title: 'Found block variables overlap: {0}'
 ---
 
-
 Forbid overlapping local and block variables.
 
 What we call local variables:
 
-1. Assigns and annotations
-2. Function arguments (they are local to the function body)
+1.  Assigns and annotations
+2.  Function arguments (they are local to the function body)
 
 What we call block variables:
 
-1. Imports
-2. Functions and async functions definitions
-3. Classes, methods, and async methods definitions
-4. For and async for loops variables
-5. Except for block exception aliases
+1.  Imports
+2.  Functions and async functions definitions
+3.  Classes, methods, and async methods definitions
+4.  For and async for loops variables
+5.  Except for block exception aliases
 
-We allow local variables to overlap themselves,
-we forbid block variables to overlap themselves.
+We allow local variables to overlap themselves, we forbid block
+variables to overlap themselves.
 
-Example::
+Example:
 
     # Correct:
     my_value = 1
     my_value = my_value + 1
-
+    
     # Wrong:
     import my_value
     my_value = 1  # overlaps with import
 
-See also:
-    https://github.com/satwikkansal/wtfPython#-explanation-20
+  - See also:  
+    <https://github.com/satwikkansal/wtfPython#-explanation-20>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS441.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS441.md
@@ -3,36 +3,46 @@ code: 441
 title: 'Found control variable used after block: {0}'
 ---
 
-
 Forbid control variables after the block body.
 
 What we call block control variables:
 
-1. ``for`` loop unpacked variables
-2. ``with`` context variables
+1.  `for` loop unpacked variables
+2.  `with` context variables
 
-Reasoning:
-    Variables leaking from the blocks can damage your logic.
-    It might not contain what you think they contain.
+<!-- end list -->
 
-Solution:
-    Use names inside the scope they are defined.
-    Create new functions to return values in case
-    you need to use block variables: when searching for a value, etc.
+  - Reasoning:  
+    Variables leaking from the blocks can damage your logic. It might
+    not contain what you think they contain.
 
-Example::
+  - Solution:  
+    Use names inside the scope they are defined. Create new functions to
+    return values in case you need to use block variables: when
+    searching for a value, etc.
+
+Example:
 
     # Correct:
     for my_item in collection:
         print(my_item)
-
+    
     # Wrong:
     for my_item in collection:
         ...
     print(my_item)
 
-See also:
-    https://github.com/satwikkansal/wtfPython#-explanation-32
+  - See also:  
+    <https://github.com/satwikkansal/wtfPython#-explanation-32>
 
-.. versionadded:: 0.12.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
+
+0.12.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS442.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS442.md
@@ -3,33 +3,34 @@ code: 442
 title: 'Found outer scope names shadowing: {0}'
 ---
 
-
 Forbid shadowing variables from outer scopes.
 
-We check the function, method, and module scopes.
-While we do not check the class scope. Because class level constants
-are not available via regular name,
-and they are scope to ``ClassName.var_name``.
+We check the function, method, and module scopes. While we do not check
+the class scope. Because class level constants are not available via
+regular name, and they are scope to `ClassName.var_name`.
 
-Reasoning:
+  - Reasoning:  
     Shadowing can lead you to a big pile of storage and unexpected bugs.
 
-
-Solution:
+  - Solution:  
     Use different names and do not allow scoping.
 
-Example::
+Example:
 
     # Correct:
     def test(): ...
-
+    
     def other():
         test1 = 1
-
+    
     # Wrong:
     def test(): ...
-
+    
     def other():
         test = 1  # shadows `test()` function
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS443.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS443.md
@@ -3,21 +3,24 @@ code: 443
 title: Found unhashable item
 ---
 
-
 Forbid explicit unhashable types of asset items and dict keys.
 
-Reasoning:
-    This will resolve in ``TypeError`` in runtime.
+  - Reasoning:  
+    This will resolve in `TypeError` in runtime.
 
-Solution:
+  - Solution:  
     Use hashable types to define set items and dict keys.
 
-Example::
+Example:
 
     # Correct:
     my_dict = {1: {}, (1, 2): [], (2, 3): {1, 2}}
-
+    
     # Wrong:
     my_dict = {[1, 2]: [], {2, 3}: {1, 2}}
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS444.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS444.md
@@ -3,37 +3,45 @@ code: 444
 title: Found incorrect keyword condition
 ---
 
-
 Forbid explicit falsely-evaluated conditions with several keywords.
 
 We check:
 
-- ``ast.While``
-- ``ast.Assert``
+  - `ast.While`
+  - `ast.Assert`
 
-We do not check variables, attributes, calls, bool and bin operators, etc.
-We forbid constants and some expressions.
+We do not check variables, attributes, calls, bool and bin operators,
+etc. We forbid constants and some expressions.
 
-Reasoning:
-    Some conditions tell us that this node won't work correctly.
-    So, we need to check if we can fix that.
+  - Reasoning:  
+    Some conditions tell us that this node won't work correctly. So, we
+    need to check if we can fix that.
 
-Solution:
+  - Solution:  
     Remove the unreachable node, or change the condition item.
 
-Example::
+Example:
 
     # Correct:
     assert some_variable
-
+    
     while True:
         ...
-
+    
     # Wrong:
     assert []
-
+    
     while False:
         ...
 
-.. versionadded:: 0.12.0
-.. versionchanged:: 0.13.0
+<div class="versionadded">
+
+0.12.0
+
+</div>
+
+<div class="versionchanged">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS445.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS445.md
@@ -3,22 +3,25 @@ code: 445
 title: Found incorrectly named keyword in the starred dict
 ---
 
-
 Forbid incorrectly named keywords in starred dicts.
 
-Reasoning:
-    Using the incorrect keywords in a starred dict.
-    Eg.: ``print(**{'@': 1})``.
+  - Reasoning:  
+    Using the incorrect keywords in a starred dict. Eg.:
+    `print(**{'@': 1})`.
 
-Solution:
+  - Solution:  
     Don't use incorrect identifiers as keywords.
 
-Example::
+Example:
 
     # Correct:
     print(**{'end': '|'})
-
+    
     # Wrong:
     print(**{'3end': '|'})
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS446.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS446.md
@@ -3,33 +3,34 @@ code: 446
 title: 'Found approximate constant: {0}'
 ---
 
-
 Forbid approximate constants.
 
-Reasoning:
-    Some constants are already defined.
-    No need to write them again, use existing values.
-    We just compare numbers as strings and raise this
+  - Reasoning:  
+    Some constants are already defined. No need to write them again, use
+    existing values. We just compare numbers as strings and raise this
     violation when they start with the same chars.
 
-Solution:
+  - Solution:  
     Use pre-defined constants.
 
-Example::
+Example:
 
     # Correct:
     from math import pi
     random_number = 3.15
     too_short = 3.1
-
+    
     # Wrong:
     pi = 3.14
 
-See
-:py:data:`~wemake_python_styleguide.constants.MATH_APPROXIMATE_CONSTANTS`
+See :py`~wemake_python_styleguide.constants.MATH_APPROXIMATE_CONSTANTS`
 for full list of math constants that we check for.
 
-See also:
-    https://docs.python.org/3/library/math.html#constants
+  - See also:  
+    <https://docs.python.org/3/library/math.html#constants>
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS447.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS447.md
@@ -3,28 +3,30 @@ code: 447
 title: 'Found alphabet as strings: {0}'
 ---
 
-
 Forbid using the alphabet as a string.
 
-Reasoning:
-    Some constants are already defined.
-    No need to write to them again, use existing values.
-    We just compare strings and raise this violation
-    when they have the same chars.
+  - Reasoning:  
+    Some constants are already defined. No need to write to them again,
+    use existing values. We just compare strings and raise this
+    violation when they have the same chars.
 
-Solution:
+  - Solution:  
     Use pre-defined constants.
 
-Example::
+Example:
 
     # Correct:
     import string
     UPPERCASE_ALPH = string.ascii_uppercase
     LOWERCASE_ALPH = string.ascii_lowercase
-
+    
     # Wrong:
     GUESS_MY_NAME = "abcde...WXYZ"
     UPPERCASE_ALPH = "ABCD...WXYZ"
     LOWERCASE_ALPH = "abcd...wxyz"
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS448.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS448.md
@@ -3,21 +3,19 @@ code: 448
 title: Found incorrect exception order
 ---
 
+Forbid incorrect order of `except`.
 
-Forbid incorrect order of ``except``.
+Note, we only check for built-in exceptions because we cannot statically
+identify the inheritance order of custom ones.
 
-Note, we only check for built-in exceptions
-because we cannot statically identify
-the inheritance order of custom ones.
+  - Reasoning:  
+    Using incorrect order of exceptions is error-prone, since you end up
+    with some unreachable exception clauses.
 
-Reasoning:
-    Using incorrect order of exceptions is error-prone, since
-    you end up with some unreachable exception clauses.
-
-Solution:
+  - Solution:  
     Use the correct order of exceptions.
 
-Example::
+Example:
 
     # Correct:
     try:
@@ -26,7 +24,7 @@ Example::
         ...
     except Exception:
         ...
-
+    
     # Wrong:
     try:
         ...
@@ -35,7 +33,11 @@ Example::
     except ValueError:
         ...
 
-See also:
-    https://bit.ly/36MHlzw
+  - See also:  
+    <https://bit.ly/36MHlzw>
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS449.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS449.md
@@ -3,26 +3,28 @@ code: 449
 title: Found float used as a key
 ---
 
+Forbid `float` keys.
 
-Forbid ``float`` keys.
+  - Reasoning:  
+    `float` is a very ugly data type. It has a lot of "precision"
+    errors. When we use `float` as keys we can hit this wall. Moreover,
+    we cannot use `float` keys with lists, by design.
 
-Reasoning:
-    ``float`` is a very ugly data type.
-    It has a lot of "precision" errors.
-    When we use ``float`` as keys we can hit this wall.
-    Moreover, we cannot use ``float`` keys with lists, by design.
-
-Solution:
+  - Solution:  
     Use other data types: integers, decimals, or use fuzzy logic.
 
-Example::
+Example:
 
     # Correct:
     some = {1: 'a'}
     some[1]
-
+    
     # Wrong:
     some = {1.0: 'a'}
     some[1.0]
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS450.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS450.md
@@ -3,27 +3,30 @@ code: 450
 title: 'Found protected object import: {0}'
 ---
 
-
 Forbid importing protected objects from modules.
 
-Related to :class:`~ProtectedModuleViolation`.
+Related to `~ProtectedModuleViolation`.
 
-Reasoning:
+  - Reasoning:  
     When importing a protected modules' members, we break the contract
-    which the authors of this module enforce.
-    By disrespecting encapsulation, we may break the code at any moment.
+    which the authors of this module enforce. By disrespecting
+    encapsulation, we may break the code at any moment.
 
-Solution:
-    Do not import protected objects from modules.
-    Respect the encapsulation.
+  - Solution:  
+    Do not import protected objects from modules. Respect the
+    encapsulation.
 
-Example::
+Example:
 
     # Correct:
     from some.public.module import FooClass
-
+    
     # Wrong:
     from some.module import _protected
     from some.module import _protected as not_protected
 
-.. versionadded:: 0.14.0
+<div class="versionadded">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS451.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS451.md
@@ -3,34 +3,35 @@ code: 451
 title: Found positional-only argument
 ---
 
+Forbid positional only or `/` arguments.
 
-Forbid positional only or ``/`` arguments.
+This violation is only raised for `python3.8+`, earlier versions do not
+have this concept.
 
-This violation is only raised for ``python3.8+``,
-earlier versions do not have this concept.
+  - Reasoning:  
+    This is a very rare case. Almost exclusively used by C code and
+    stdlib. There's no point in declaring your own parameters as
+    positional only. It will break your code\!
 
-Reasoning:
-    This is a very rare case.
-    Almost exclusively used by C code and stdlib.
-    There's no point in declaring your own parameters as positional only.
-    It will break your code!
+  - Solution:  
+    Use regular arguments. In case you are working with C, then this
+    violation can be ignored.
 
-Solution:
-    Use regular arguments.
-    In case you are working with C, then this violation
-    can be ignored.
-
-Example::
+Example:
 
     # Correct:
     def my_function(first, second):
         ...
-
+    
     # Wrong:
     def my_function(first, /, second):
         ...
 
-See also:
-    https://www.python.org/dev/peps/pep-0570/
+  - See also:  
+    <https://www.python.org/dev/peps/pep-0570/>
 
-.. versionadded:: 0.14.0
+<div class="versionadded">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS452.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS452.md
@@ -3,38 +3,41 @@ code: 452
 title: Found `break` or `continue` in `finally` block
 ---
 
+Forbid `break` and `continue` in a `finally` block.
 
-Forbid ``break`` and ``continue`` in a ``finally`` block.
+Related to `~TryExceptMultipleReturnPathViolation`.
 
-Related to :class:`~TryExceptMultipleReturnPathViolation`.
+  - Reasoning:  
+    Putting any control statements in
+    <span class="title-ref">finally</span> is a terrible practice,
+    because <span class="title-ref">finally</span> is implicitly called
+    and can cause damage to your logic with its implicitness. It should
+    not be allowed.
 
-Reasoning:
-    Putting any control statements in `finally` is a
-    terrible practice, because `finally` is implicitly
-    called and can cause damage to your logic with
-    its implicitness.
-    It should not be allowed.
+  - Solution:  
+    Remove `break` and `continue` from `finally` blocks.
 
-Solution:
-    Remove ``break`` and ``continue`` from ``finally`` blocks.
-
-Example::
+Example:
 
     # Correct:
     try:
         ...
     finally:
         ...
-
+    
     # Wrong:
     try:
         ...
     finally:
         break
-
+    
     try:
         ...
     finally:
         continue
 
-.. versionadded:: 0.14.0
+<div class="versionadded">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS453.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS453.md
@@ -3,30 +3,34 @@ code: 453
 title: 'Found executable mismatch: {0}'
 ---
 
-
 Forbid executing a file with shebang incorrectly set.
 
-A violation is raised in these cases :
-    - Shebang is present but the file is not executable.
-    - The file is executable but no shebang is present.
-    - Shebang is present but does not contain "python".
-    - Whitespace is present before the shebang.
-    - Presence of blank lines or commented lines before the shebang.
+  - A violation is raised in these cases :
+    
+      - Shebang is present but the file is not executable.
+      - The file is executable but no shebang is present.
+      - Shebang is present but does not contain "python".
+      - Whitespace is present before the shebang.
+      - Presence of blank lines or commented lines before the shebang.
 
-Reasoning:
+  - Reasoning:  
     Setting the shebang incorrectly causes an executable mismatch.
 
-Solution:
-    Ensure that the shebang is present on the first line,
-    and contains "python", and there is no leading whitespace.
+  - Solution:  
+    Ensure that the shebang is present on the first line, and contains
+    "python", and there is no leading whitespace.
 
-Example::
+Example:
 
     # Correct:
     #!/usr/bin/env python
-
+    
     # Wrong:
     #!/usr/bin/env
         #!/usr/bin/env python
 
-.. versionadded:: 0.14.0
+<div class="versionadded">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS454.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS454.md
@@ -3,30 +3,33 @@ code: 454
 title: 'Found wrong `raise` exception type: {0}'
 ---
 
+Forbid raising `Exception` or `BaseException`.
 
-Forbid raising ``Exception`` or ``BaseException``.
+  - Reasoning:  
+    `Exception` and `BaseException` are inconvenient to catch. And when
+    you catch them you can accidentally suppress other exceptions.
 
-Reasoning:
-    ``Exception`` and ``BaseException`` are inconvenient to catch.
-    And when you catch them you can accidentally suppress other exceptions.
+  - Solution:  
+    Use a user-defined exception, subclassed from `Exception`.
 
-Solution:
-    Use a user-defined exception, subclassed from ``Exception``.
-
-Example::
+Example:
 
     # Correct:
     raise UserNotFoundError
     raise UserNotFoundError("cannot find user with the given id")
-
+    
     # Wrong:
     raise Exception
     raise Exception("user not found")
     raise BaseException
     raise BaseException("user not found")
 
-See also:
-    https://docs.python.org/3/library/exceptions.html#exception-hierarchy
-    https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions
+  - See also:  
+    <https://docs.python.org/3/library/exceptions.html#exception-hierarchy>
+    <https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions>
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS455.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS455.md
@@ -3,19 +3,18 @@ code: 455
 title: Found non-trivial expression as an argument for "except"
 ---
 
+Forbids using non-trivial expressions as a parameter for `except`.
 
-Forbids using non-trivial expressions as a parameter for ``except``.
+  - Reasoning:  
+    Expressions used as an argument for `except` could be hard to read
+    and hide real list of exceptions being expected to occur in the
+    outlined code block.
 
-Reasoning:
-    Expressions used as an argument for ``except`` could be hard to read
-    and hide real list of exceptions being expected
-    to occur in the outlined code block.
-
-Solution:
-    Use separate ``except`` blocks for each exception or provide a tuple
+  - Solution:  
+    Use separate `except` blocks for each exception or provide a tuple
     of exception classes.
 
-Example::
+Example:
 
     # Correct:
     try:
@@ -24,16 +23,20 @@ Example::
         ...
     except TypeError:
         ...
-
+    
     try:
         ...
     except (TypeError, ValueError):
         ...
-
+    
     # Wrong:
     try:
         ...
     except TypeError or ValueError:
         ...
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS456.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS456.md
@@ -3,22 +3,25 @@ code: 456
 title: Found "NaN" as argument to float()
 ---
 
+Forbids using `float("NaN")` construct to generate NaN.
 
-Forbids using ``float("NaN")`` construct to generate NaN.
-
-Reasoning:
+  - Reasoning:  
     This method to generate NaN is really confusing and is a good way to
     catch a lot of unexpected bugs.
 
-Solution:
-    Even if you're 100% sure what you're doing, use ``math.nan`` instead.
+  - Solution:  
+    Even if you're 100% sure what you're doing, use `math.nan` instead.
 
-Example::
+Example:
 
     # Correct:
     min(math.nan, 3)
-
+    
     # Wrong:
     min(float("NAN"), 3)
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS457.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS457.md
@@ -3,24 +3,27 @@ code: 457
 title: Found an infinite while loop
 ---
 
+Forbids use of infinite `while True:` loops.
 
-Forbids use of infinite ``while True:`` loops.
-
-Reasoning:
+  - Reasoning:  
     Infinite loops will cause bugs in code.
 
-Solution:
+  - Solution:  
     Add either a return, raise, or break to handle the infinite loop.
 
-Example::
+Example:
 
     # Correct:
     while True:
         print('forever')
         break
-
+    
     # Wrong:
     while True:
         print('forever')
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS458.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS458.md
@@ -3,31 +3,34 @@ code: 458
 title: 'Found imports collision: {0}'
 ---
 
-
 Forbids to import from already imported modules.
 
-Reasoning:
-    Importing objects from already imported modules is inconsistent
-    and error-prone.
+  - Reasoning:  
+    Importing objects from already imported modules is inconsistent and
+    error-prone.
 
-Solution:
+  - Solution:  
     Do not import objects from already imported modules or use aliases
     when it cannot be avoided.
 
-Example::
+Example:
 
     # Correct:
     import public
     from public.module import FooClass
-
+    
     import hypothesis
     from hypothesis import strategies as st
-
+    
     # Wrong:
     from public import utils
     from public.utils import something
-
+    
     import hypothesis
     from hypothesis import strategies
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS459.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS459.md
@@ -3,29 +3,30 @@ code: 459
 title: Found comparison with float or complex number
 ---
 
+Forbids comparisons with `float` and `complex`.
 
-Forbids comparisons with ``float`` and ``complex``.
+  - Reasoning:  
+    This is a best practice rule, as `float` and `complex` suffer from
+    representation error, leading to possibly incorrect results during
+    comparison.
 
-Reasoning:
-    This is a best practice rule, as ``float`` and ``complex``
-    suffer from representation error, leading to possibly
-    incorrect results during comparison.
+  - Solution:  
+    Use fuzzy operators. 1. `abs(f1 - f2) <= allowed_error` 2.
+    `math.isclose(f1, f2)` (for `float`) 3. `cmath.isclose(c1, c2)` (for
+    `complex`) 4. Custom logic, not using operators
 
-Solution:
-    Use fuzzy operators.
-    1. ``abs(f1 - f2) <= allowed_error``
-    2. ``math.isclose(f1, f2)`` (for ``float``)
-    3. ``cmath.isclose(c1, c2)`` (for ``complex``)
-    4. Custom logic, not using operators
-
-Example::
+Example:
 
     # Correct:
     math.isclose(3.0, 0.3 / 0.1)
     cmath.isclose(3 + 4j, (0.3 + 0.4j) / 0.1)
-
+    
     # Wrong:
     3.0 == 0.3 / 0.1
     3 + 4j == (0.3 + 0.4j) / 0.1
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS460.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS460.md
@@ -3,21 +3,24 @@ code: 460
 title: Found single element destructuring
 ---
 
-
 Forbids to have single element destructuring.
 
-Reasoning:
+  - Reasoning:  
     Having single element destructuring is not readable.
 
-Solution:
+  - Solution:  
     Use access by index instead.
 
-Example::
+Example:
 
     # Correct:
     first = single_element_list[0]
-
+    
     # Wrong:
     (first,) = [1]
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS461.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS461.md
@@ -3,22 +3,26 @@ code: 461
 title: 'Forbidden inline ignore: {0}'
 ---
 
-
 Forbids to use specific inline ignore violations.
 
-There can be forbidden a specific violation or whole
-class of violations.
+There can be forbidden a specific violation or whole class of
+violations.
 
-Reasoning:
-    There are violations important for specific project that must not
-    be ignored, e.g. complexity or best practices violations.
+  - Reasoning:  
+    There are violations important for specific project that must not be
+    ignored, e.g. complexity or best practices violations.
 
-Solution:
+  - Solution:  
     Remove inline ignore for forbidden violations.
 
-Configuration:
-    This rule is configurable with `--forbidden-inline-ignore``.
+  - Configuration:  
+    This rule is configurable with
+    <span class="title-ref">--forbidden-inline-ignore</span><span class="title-ref">.
     Default:
-    :str:`wemake_python_styleguide.options.defaults.FORBIDDEN_INLINE_IGNORE`
+    :str:\`wemake\_python\_styleguide.options.defaults.FORBIDDEN\_INLINE\_IGNORE</span>
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS461.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS461.md
@@ -19,7 +19,7 @@ violations.
     This rule is configurable with
     <span class="title-ref">--forbidden-inline-ignore</span><span class="title-ref">.
     Default:
-    :str:\`wemake\_python\_styleguide.options.defaults.FORBIDDEN\_INLINE\_IGNORE</span>
+    </span><span class="title-ref">python://wemake\_python\_styleguide.options.defaults.FORBIDDEN\_INLINE\_IGNORE</span>\`
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS462.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS462.md
@@ -3,32 +3,35 @@ code: 462
 title: Wrong multiline string usage
 ---
 
-
 Frobids direct usage of multiline strings.
 
-Multiline strings are only allowed in docstrings
-or assignments to variables.
+Multiline strings are only allowed in docstrings or assignments to
+variables.
 
-Reasoning:
-    Direct usage of multiline strings is not readable.
-    One should not depend on the current indentation,
-    e.g. in comparisons or function calls.
+  - Reasoning:  
+    Direct usage of multiline strings is not readable. One should not
+    depend on the current indentation, e.g. in comparisons or function
+    calls.
 
-Solution:
+  - Solution:  
     Assign a multiline string to a variable.
 
-Example::
+Example:
 
     # Correct:
     multiline = """
         abc
         abc
     """
-
+    
     # Wrong:
     function("""
         abc
         abc
     """)
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS463.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS463.md
@@ -3,27 +3,31 @@ code: 463
 title: Found a getter without a return value
 ---
 
-
-Forbids to have functions starting with ``get_`` without returning a value.
+Forbids to have functions starting with `get_` without returning a
+value.
 
 Applies to both methods and functions.
 
-Reasoning:
-    A ``get_`` function is generally expected to return a value. Otherwise,
-    it is most likely either an error or bad naming.
+  - Reasoning:  
+    A `get_` function is generally expected to return a value.
+    Otherwise, it is most likely either an error or bad naming.
 
-Solution:
-    Make sure getter functions ``return`` or ``yield`` a value on all
+  - Solution:  
+    Make sure getter functions `return` or `yield` a value on all
     execution paths, or rename the function.
 
-Example::
+Example:
 
     # Correct:
     def get_random_number():
          return random.randint(1, 10)
-
+    
     # Wrong:
     def get_random_number():
          print('I do not return a value!')
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS464.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS464.md
@@ -3,31 +3,34 @@ code: 464
 title: Found empty comment
 ---
 
-
 Forbid empty comments.
 
 Empty comments are only allowed in between valid comments.
 
-Reasoning:
+  - Reasoning:  
     Empty comments that do not help formatting should be excluded.
 
-Solution:
+  - Solution:  
     Remove the empty comments.
 
-Example::
+Example:
 
     # Correct:
-
+    
     # First line
     #
     # Samples:
     # One
     # Two
     my_var = 1
-
+    
     # Wrong:
-
+    
     #
     my_var = 1
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS465.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS465.md
@@ -3,25 +3,28 @@ code: 465
 title: Found likely bitwise and boolean operation mixup
 ---
 
-
 Forbid comparisons between bitwise and boolean expressions.
 
 Empty comments are only allowed in between valid comments.
 
-Reasoning:
-   This case indicates that a person
-   confused ``&`` with ``and`` and ``|`` with ``or``.
-   This can be the case if a person is coming from another language.
+  - Reasoning:  
+    This case indicates that a person confused `&` with `and` and `|`
+    with `or`. This can be the case if a person is coming from another
+    language.
 
-Solution:
+  - Solution:  
     Change bitwise operator to boolean operators.
 
-Example::
+Example:
 
     # Correct:
     first | 10
-
+    
     # Wrong:
     result = ((first > 0) & False)
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS466.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS466.md
@@ -3,29 +3,32 @@ code: 466
 title: Found new-styled decorator
 ---
 
-
 Forbid using complex grammar for using decorators.
 
-This violation is only raised for ``python3.9+``,
-earlier versions do not have this concept.
+This violation is only raised for `python3.9+`, earlier versions do not
+have this concept.
 
-Reasoning:
-   New grammar allows to use decorators in a more liberal way.
-   It is probably not a good idea.
-   Because decorators should be simple and easy to read.
+  - Reasoning:  
+    New grammar allows to use decorators in a more liberal way. It is
+    probably not a good idea. Because decorators should be simple and
+    easy to read.
 
-Solution:
-    Use names, attributes, and calls as decorators only.
-    You are free to pass any args to function calls, however.
+  - Solution:  
+    Use names, attributes, and calls as decorators only. You are free to
+    pass any args to function calls, however.
 
-Example::
+Example:
 
     # Correct:
     @some.decorator(args)
     def my_function(): ...
-
+    
     # Wrong:
     @some.decorator['method'] + other
     def my_function(): ...
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS500.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS500.md
@@ -3,22 +3,20 @@ code: 500
 title: Found `else` in a loop without `break`
 ---
 
+Forbid `else` without `break` in a loop.
 
-Forbid ``else`` without ``break`` in a loop.
+We use the same logic for `for` and `while` loops.
 
-We use the same logic for ``for`` and ``while`` loops.
+  - Reasoning:  
+    When there's no `break` keyword in loop's body it means that `else`
+    will always be called. This rule will reduce complexity, improve
+    readability, and protect from possible errors.
 
-Reasoning:
-    When there's no ``break`` keyword in loop's body it means
-    that ``else`` will always be called.
-    This rule will reduce complexity, improve readability,
-    and protect from possible errors.
+  - Solution:  
+    Refactor your `else` case logic to be inside the loop's body. Or
+    right after it.
 
-Solution:
-    Refactor your ``else`` case logic to be inside the loop's body.
-    Or right after it.
-
-Example::
+Example:
 
     # Correct:
     for letter in 'abc':
@@ -26,16 +24,25 @@ Example::
             break
     else:
         print('"b" is not found')
-
+    
     for letter in 'abc':
         print(letter)
     print('always called')
-
+    
     # Wrong:
     for letter in 'abc':
         print(letter)
     else:
         print('always called')
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS501.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS501.md
@@ -3,27 +3,26 @@ code: 501
 title: Found `finally` in `try` block without `except`
 ---
 
+Forbid `finally` in `try` block without `except` block.
 
-Forbid ``finally`` in ``try`` block without ``except`` block.
+However, we allow to use `try` with just `finally` block when function
+or method is decorated. Because we cannot control what is going on in
+this decorator. It might be `@contextmanager` or similar thing that
+requires this API.
 
-However, we allow to use ``try`` with just ``finally`` block
-when function or method is decorated. Because we cannot control
-what is going on in this decorator.
-It might be ``@contextmanager`` or similar thing that requires this API.
-
-Reasoning:
+  - Reasoning:  
     This rule will reduce complexity and improve readability.
 
-Solution:
-    Refactor your ``try`` logic.
-    Replace the ``try-finally`` statement with a ``with`` statement.
+  - Solution:  
+    Refactor your `try` logic. Replace the `try-finally` statement with
+    a `with` statement.
 
-Example::
+Example:
 
     # Correct:
     with open("filename") as f:
         f.write(...)
-
+    
     # Wrong:
     try:
         f = open("filename")
@@ -31,6 +30,20 @@ Example::
     finally:
         f.close()
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS502.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS502.md
@@ -3,29 +3,37 @@ code: 502
 title: Found simplifiable `if` condition
 ---
 
+Forbid simplifiable `if` conditions.
 
-Forbid simplifiable ``if`` conditions.
-
-Reasoning:
+  - Reasoning:  
     These complex constructions can cause frustration among other
     developers. They are longer, more verbose, and more complex.
 
-Solution:
-    Either use ``bool()`` to convert test values to boolean values, or just
-    leave it as it is in case your test already returns a boolean value.
-    Use can also use ``not`` keyword to switch boolean values.
+  - Solution:  
+    Either use `bool()` to convert test values to boolean values, or
+    just leave it as it is in case your test already returns a boolean
+    value. Use can also use `not` keyword to switch boolean values.
 
-Example::
+Example:
 
     # Correct:
     my_bool = bool(some_call())
     other_value = 8 if some_call() else None
-
+    
     # Wrong:
     my_bool = True if some_call() else False
 
-We only check ``if`` nodes where ``True`` and ``False`` values are used.
-We check both ``if`` nodes and ``if`` expressions.
+We only check `if` nodes where `True` and `False` values are used. We
+check both `if` nodes and `if` expressions.
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS503.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS503.md
@@ -3,31 +3,28 @@ code: 503
 title: Found useless returning `else` statement
 ---
 
+Forbid useless `else` cases in returning functions.
 
-Forbid useless ``else`` cases in returning functions.
+We check single `if`, `for`, `while`, and `try` statements that all
+contain `return`, `raise`, `continue`, or `break` statements with this
+rule.
 
-We check single ``if``, ``for``, ``while``, and ``try``
-statements that all contain
-``return``, ``raise``, ``continue``, or ``break``
-statements with this rule.
+  - Reasoning:  
+    Using extra `else` creates a situation when the whole node could and
+    should be dropped without any changes in logic. So, we prefer to
+    have less code than more code.
 
-Reasoning:
-    Using extra ``else`` creates a situation when
-    the whole node could and should be dropped
-    without any changes in logic.
-    So, we prefer to have less code than more code.
+  - Solution:  
+    Remove useless `else` case.
 
-Solution:
-    Remove useless ``else`` case.
-
-Example::
+Example:
 
     # Correct:
     def some_function():
         if some_call():
             return 'yeap'
         return 'nope'
-
+    
     # Wrong:
     def some_function():
         if some_call():
@@ -35,6 +32,20 @@ Example::
         else:
             raise ValueError('nope')
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.15.1
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.15.1
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS504.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS504.md
@@ -3,37 +3,45 @@ code: 504
 title: Found negated condition
 ---
 
+Forbid negated conditions together with `else` clause.
 
-Forbid negated conditions together with ``else`` clause.
-
-Reasoning:
+  - Reasoning:  
     It easier to read and name regular conditions. Not negated ones.
 
-Solution:
-    Move actions from the negated ``if`` condition to the ``else``
+  - Solution:  
+    Move actions from the negated `if` condition to the `else`
     condition.
 
-Example::
+Example:
 
     # Correct:
     if some == 1:
          ...
     else:
          ...
-
+    
     if not some:
          ...
-
+    
     if not some:
         ...
     elif other:
         ...
-
+    
     # Wrong:
     if not some:
          ...
     else:
          ...
 
-.. versionadded:: 0.8.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.8.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS505.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS505.md
@@ -3,26 +3,21 @@ code: 505
 title: Found nested `try` block
 ---
 
+Forbid nested `try` blocks.
 
-Forbid nested ``try`` blocks.
+Notice, we check all possible slots for `try` block: 1. the `try` block
+itself 2. all `except` cases 3. `else` case 4. and `finally` case
 
-Notice, we check all possible slots for ``try`` block:
-1. the ``try`` block itself
-2. all ``except`` cases
-3. ``else`` case
-4. and ``finally`` case
+  - Reasoning:  
+    Nesting `try` blocks indicates that something really bad happens to
+    your logic. Why does it require two separate exception handlers? It
+    is a perfect case to refactor your code.
 
-Reasoning:
-    Nesting ``try`` blocks indicates
-    that something really bad happens to your logic.
-    Why does it require two separate exception handlers?
-    It is a perfect case to refactor your code.
+  - Solution:  
+    Collapse two exception handlers together. Or create a separate
+    function that will handle this second nested case.
 
-Solution:
-    Collapse two exception handlers together.
-    Or create a separate function that will handle this second nested case.
-
-Example::
+Example:
 
     # Wrong:
     try:
@@ -32,7 +27,7 @@ Example::
             ...
     except SomeOtherException:
         ...
-
+    
     try:
         ...
     except SomeOtherException:
@@ -41,5 +36,14 @@ Example::
         except SomeException:
             ...
 
-.. versionadded:: 0.8.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.8.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS506.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS506.md
@@ -3,25 +3,33 @@ code: 506
 title: Found useless lambda declaration
 ---
 
+Forbid useless proxy `lambda` expressions.
 
-Forbid useless proxy ``lambda`` expressions.
+  - Reasoning:  
+    Sometimes developers tend to overuse `lambda` expressions and they
+    wrap code that can be passed as is, without extra wrapping. The code
+    without extra `lambda` is easier to read and is more performant.
 
-Reasoning:
-    Sometimes developers tend to overuse ``lambda`` expressions
-    and they wrap code that can be passed as is, without extra wrapping.
-    The code without extra ``lambda`` is easier
-    to read and is more performant.
+  - Solution:  
+    Remove wrapping `lambda` declaration, use just the internal
+    function.
 
-Solution:
-    Remove wrapping ``lambda`` declaration, use just the internal function.
-
-Example::
+Example:
 
     # Correct:
     numbers = map(int, ['1', '2'])
-
+    
     # Wrong:
     numbers = map(lambda string: int(string), ['1', '2'])
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS507.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS507.md
@@ -3,29 +3,37 @@ code: 507
 title: Found useless `len()` compare
 ---
 
-
 Forbid unpythonic zero-length compare.
 
-Note, that we allow to check arbitrary length, like ``len(arr) == 3``.
+Note, that we allow to check arbitrary length, like `len(arr) == 3`.
 
-Reasoning:
-    Python's structures like dicts, lists, sets, and tuples
-    all have ``__bool__`` method to checks their length.
-    So, there's no point in wrapping them into ``len(...)``
-    and checking that it is bigger that ``0`` or less then ``1``, etc.
+  - Reasoning:  
+    Python's structures like dicts, lists, sets, and tuples all have
+    `__bool__` method to checks their length. So, there's no point in
+    wrapping them into `len(...)` and checking that it is bigger that
+    `0` or less then `1`, etc.
 
-Solution:
-    Remove extra ``len()`` call.
+  - Solution:  
+    Remove extra `len()` call.
 
-Example::
+Example:
 
     # Correct:
     if some_array or not other_array or len(third_array) == 1:
         ...
-
+    
     # Wrong:
     if len(some_array) > 0 or len(other_array) < 1:
         ...
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS508.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS508.md
@@ -3,25 +3,33 @@ code: 508
 title: Found incorrect `not` with compare usage
 ---
 
+Forbid `not` with compare expressions.
 
-Forbid ``not`` with compare expressions.
+  - Reasoning:  
+    This version of `not` operator is unreadable.
 
-Reasoning:
-    This version of ``not`` operator is unreadable.
+  - Solution:  
+    Refactor the expression without `not` operator. Change the compare
+    signs.
 
-Solution:
-    Refactor the expression without ``not`` operator.
-    Change the compare signs.
-
-Example::
+Example:
 
     # Correct:
     if x <= 5:
         ...
-
+    
     # Wrong:
     if not x > 5:
         ...
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS509.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS509.md
@@ -3,31 +3,41 @@ code: 509
 title: Found incorrectly nested ternary
 ---
 
-
 Forbid nesting ternary expressions in certain places.
 
 Note, that we restrict to nest ternary expressions inside:
 
-- ``if`` conditions
-- boolean and binary operations like ``and`` or ``+``
-- unary operators
+  - `if` conditions
+  - boolean and binary operations like `and` or `+`
+  - unary operators
 
-Reasoning:
-    Nesting ternary in random places can lead to very hard
-    debug and testing problems.
+<!-- end list -->
 
-Solution:
-    Refactor the ternary expression to be either a new variable,
-    or nested ``if`` statement, or a new function.
+  - Reasoning:  
+    Nesting ternary in random places can lead to very hard debug and
+    testing problems.
 
-Example::
+  - Solution:  
+    Refactor the ternary expression to be either a new variable, or
+    nested `if` statement, or a new function.
+
+Example:
 
     # Correct:
     some = x if cond() else y
-
+    
     # Wrong:
     if x if cond() else y:
         ...
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS510.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS510.md
@@ -3,32 +3,43 @@ code: 510
 title: Found `in` used with a non-set container
 ---
 
+Forbid `in` with static containers except `set` nodes.
 
-Forbid ``in`` with static containers except ``set`` nodes.
+We enforce people to use sets as a static containers. You can also use
+variables, calls, methods, etc. Dynamic values are not checked.
 
-We enforce people to use sets as a static containers.
-You can also use variables, calls, methods, etc.
-Dynamic values are not checked.
+  - Reasoning:  
+    Using static `list`, `tuple`, or `dict` elements to check that some
+    element is inside the container is a bad practice. Because we need
+    to iterate all over the container to find the element. Sets are the
+    best suit for this task. Moreover, it makes your code consistent.
 
-Reasoning:
-    Using static ``list``, ``tuple``, or ``dict`` elements
-    to check that some element is inside the container is a bad practice.
-    Because we need to iterate all over the container to find the element.
-    Sets are the best suit for this task.
-    Moreover, it makes your code consistent.
+  - Solution:  
+    Use `set` elements or comprehensions to check that something is
+    contained in a container.
 
-Solution:
-    Use ``set`` elements or comprehensions to check that something
-    is contained in a container.
-
-Example::
+Example:
 
     # Correct:
     print(needle in {'one', 'two'})
-
+    
     # Wrong:
     print(needle in ['one', 'two'])
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.14.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS511.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS511.md
@@ -3,27 +3,34 @@ code: 511
 title: 'Found separate `isinstance` calls that can be merged for: {0}'
 ---
 
+Forbid multiple `isinstance` calls on the same variable.
 
-Forbid multiple ``isinstance`` calls on the same variable.
+  - Reasoning:  
+    The best practice is to use `isinstance` with tuple as the second
+    argument, instead of multiple conditions joined with `or`.
 
-Reasoning:
-    The best practice is to use ``isinstance`` with tuple
-    as the second argument, instead of multiple conditions
-    joined with ``or``.
-
-Solution:
+  - Solution:  
     Use tuple of types as the second argument.
 
-Example::
+Example:
 
     # Correct:
     isinstance(some, (int, float))
-
+    
     # Wrong:
     isinstance(some, int) or isinstance(some, float)
 
-See also:
-    https://docs.python.org/3/library/functions.html#isinstance
+  - See also:  
+    <https://docs.python.org/3/library/functions.html#isinstance>
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS512.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS512.md
@@ -3,26 +3,34 @@ code: 512
 title: Found `isinstance` call with a single element tuple
 ---
 
+Forbid multiple `isinstance` calls with single-item tuples.
 
-Forbid multiple ``isinstance`` calls with single-item tuples.
+  - Reasoning:  
+    There's no need to use tuples with single elements. You can use
+    single variables or tuples with multiple elements.
 
-Reasoning:
-    There's no need to use tuples with single elements.
-    You can use single variables or tuples with multiple elements.
-
-Solution:
+  - Solution:  
     Use tuples with multiple elements or a single variable.
 
-Example::
+Example:
 
     # Correct:
     isinstance(some, (int, float))
     isinstance(some, int)
-
+    
     # Wrong:
     isinstance(some, (int, ))
 
-See: https://docs.python.org/3/library/functions.html#isinstance
+See: <https://docs.python.org/3/library/functions.html#isinstance>
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS513.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS513.md
@@ -3,24 +3,23 @@ code: 513
 title: Found implicit `elif` condition
 ---
 
+Forbid implicit `elif` conditions.
 
-Forbid implicit ``elif`` conditions.
+  - Reasoning:  
+    Nested `if` in `else` cases are bad for readability because of the
+    nesting level.
 
-Reasoning:
-    Nested ``if`` in ``else`` cases are bad
-    for readability because of the nesting level.
+  - Solution:  
+    Use `elif` on the same level.
 
-Solution:
-    Use ``elif`` on the same level.
-
-Example::
+Example:
 
     # Correct:
     if some:
         ...
     elif other:
         ...
-
+    
     # Wrong:
     if some:
         ...
@@ -28,4 +27,8 @@ Example::
         if other:
             ...
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS514.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS514.md
@@ -3,28 +3,34 @@ code: 514
 title: Found implicit `in` condition
 ---
 
-
 Forbid multiple equality comparisons with the same variable.
 
-Reasoning:
-    Using double+ equality compare with ``or``
-    or double+ non-equality compare with ``and``
-    indicates that you have implicit ``in`` or ``not in`` condition.
-    It is just hidden from you.
+  - Reasoning:  
+    Using double+ equality compare with `or` or double+ non-equality
+    compare with `and` indicates that you have implicit `in` or `not in`
+    condition. It is just hidden from you.
 
-Solution:
-    Refactor compares to use ``in`` or ``not in`` clauses.
+  - Solution:  
+    Refactor compares to use `in` or `not in` clauses.
 
-
-Example::
+Example:
 
     # Correct:
     print(some in {'first', 'second'})
     print(some not in {'first', 'second'})
-
+    
     # Wrong:
     print(some == 'first' or some == 'second')
     print(some != 'first' and some != 'second')
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS515.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS515.md
@@ -3,25 +3,28 @@ code: 515
 title: Found `open()` used without a context manager
 ---
 
+Forbid `open()` without a context manager.
 
-Forbid ``open()`` without a context manager.
+  - Reasoning:  
+    When you `open()` something, you need to close it. When using a
+    context manager - it is automatically done for you. When not using
+    it - you might find yourself in a situation when file is not closed
+    and is not accessible anymore.
 
-Reasoning:
-    When you ``open()`` something, you need to close it.
-    When using a context manager - it is automatically done for you.
-    When not using it - you might find yourself in a situation
-    when file is not closed and is not accessible anymore.
+  - Solution:  
+    Refactor `open()` call to use `with`.
 
-Solution:
-    Refactor ``open()`` call to use ``with``.
-
-Example::
+Example:
 
     # Correct:
     with open(filename) as file_obj:
         ...
-
+    
     # Wrong:
     file_obj = open(filename)
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS516.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS516.md
@@ -3,24 +3,27 @@ code: 516
 title: Found `type()` used to compare types
 ---
 
+Forbid comparing types with `type()` function.
 
-Forbid comparing types with ``type()`` function.
+  - Reasoning:  
+    When you compare types with `type()` function call it means that you
+    break polymorphism and disallow child classes of a node to work
+    here. That's incorrect.
 
-Reasoning:
-    When you compare types with ``type()`` function call
-    it means that you break polymorphism and disallow child classes
-    of a node to work here. That's incorrect.
+  - Solution:  
+    Use `isinstance` to compare types.
 
-Solution:
-    Use ``isinstance`` to compare types.
-
-Example::
+Example:
 
     # Correct:
     print(something, type(something))
-
+    
     # Wrong:
     if type(something) == int:
         ...
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS517.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS517.md
@@ -3,28 +3,28 @@ code: 517
 title: Found pointless starred expression
 ---
 
-
 Forbid useless starred expressions.
 
-Reasoning:
-    Using starred expression with constants is useless.
-    This piece of code can be rewritten to be flat.
-    Eg.: ``print(*[1, 2, 3])`` is ``print(1, 2, 3)``.
+  - Reasoning:  
+    Using starred expression with constants is useless. This piece of
+    code can be rewritten to be flat. Eg.: `print(*[1, 2, 3])` is
+    `print(1, 2, 3)`.
 
-Solution:
-    Refactor your code not to use starred expressions
-    with ``list``, ``dict``, ``tuple``, and ``set`` constants.
-    Use regular argument passing instead.
+  - Solution:  
+    Refactor your code not to use starred expressions with `list`,
+    `dict`, `tuple`, and `set` constants. Use regular argument passing
+    instead.
 
-{% raw %}
-!!! Example
-    ```python
-        # Correct:
-        my_list = [1, 2, 3, *other_iterable]
+Example:
+
+    # Correct:
+    my_list = [1, 2, 3, *other_iterable]
     
-        # Wrong:
-        print(*[1, 2, 3], **{{}})
-    ```
-{% endraw %}
+    # Wrong:
+    print(*[1, 2, 3], **{{}})
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS517.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS517.md
@@ -21,7 +21,7 @@ Example:
     my_list = [1, 2, 3, *other_iterable]
     
     # Wrong:
-    print(*[1, 2, 3], **{{}})
+    print(*[1, 2, 3], **{{ '{{' }}}})
 
 <div class="versionadded">
 

--- a/docs/wemake-python-styleguide/0.15.2/WPS518.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS518.md
@@ -3,27 +3,30 @@ code: 518
 title: Found implicit `enumerate()` call
 ---
 
+Forbid implicit `enumerate()` calls.
 
-Forbid implicit ``enumerate()`` calls.
+  - Reasoning:  
+    Using `range(len(...))` is not pythonic. Python uses collection
+    iterators, not index-based loops.
 
-Reasoning:
-    Using ``range(len(...))`` is not pythonic.
-    Python uses collection iterators, not index-based loops.
+  - Solution:  
+    Use `enumerate(...)` instead of `range(len(...))`.
 
-Solution:
-    Use ``enumerate(...)`` instead of ``range(len(...))``.
-
-Example::
+Example:
 
     # Correct:
     for index, person in enumerate(people):
         ...
-
+    
     # Wrong:
     for index in range(len(people)):
         ...
 
-See also:
-    https://docs.python.org/3/library/functions.html#enumerate
+  - See also:  
+    <https://docs.python.org/3/library/functions.html#enumerate>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS519.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS519.md
@@ -3,34 +3,37 @@ code: 519
 title: Found implicit `sum()` call
 ---
 
+Forbid implicit `sum()` calls.
 
-Forbid implicit ``sum()`` calls.
+When summing types different from numbers, you might need to provide the
+second argument to the `sum` function: `sum([[1], [2], [3]], [])`
 
-When summing types different from numbers, you might need to provide
-the second argument to the ``sum`` function: ``sum([[1], [2], [3]], [])``
+You might also use `str.join` to join iterable of strings.
 
-You might also use ``str.join`` to join iterable of strings.
+  - Reasoning:  
+    Using `for` loops with `+=` assign inside indicates that you
+    iteratively sum things inside your collection. That's what `sum()`
+    builtin function does.
 
-Reasoning:
-    Using ``for`` loops with ``+=`` assign inside indicates
-    that you iteratively sum things inside your collection.
-    That's what ``sum()`` builtin function does.
+  - Solution:  
+    Use `sum(...)` instead of a loop with `+=` operation.
 
-Solution:
-    Use ``sum(...)`` instead of a loop with ``+=`` operation.
-
-Example::
+Example:
 
     # Correct:
     sum_result = sum(get_elements())
-
+    
     # Wrong:
     sum_result = 0
     for to_sum in get_elements():
         sum_result += to_sum
 
-See also:
-    https://docs.python.org/3/library/functions.html#sum
-    https://docs.python.org/3/library/stdtypes.html#str.join
+  - See also:  
+    <https://docs.python.org/3/library/functions.html#sum>
+    <https://docs.python.org/3/library/stdtypes.html#str.join>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS520.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS520.md
@@ -3,34 +3,36 @@ code: 520
 title: Found compare with falsy constant
 ---
 
-
 Forbid comparing with explicit falsy constants.
 
-We allow to compare with falsy numbers, strings, booleans, ``None``.
-We disallow complex constants like tuple, dicts, and lists.
+We allow to compare with falsy numbers, strings, booleans, `None`. We
+disallow complex constants like tuple, dicts, and lists.
 
-Reasoning:
-    When comparing ``something`` with explicit falsy constants
-    what we really mean is ``not something``.
+  - Reasoning:  
+    When comparing `something` with explicit falsy constants what we
+    really mean is `not something`.
 
-Solution:
-    Use ``not`` with your variable.
-    Fix your data types.
+  - Solution:  
+    Use `not` with your variable. Fix your data types.
 
-Example::
+Example:
 
     # Correct:
     if not my_check:
         ...
-
+    
     if some_other is None:
         ...
-
+    
     if some_num == 0:
         ...
-
+    
     # Wrong:
     if my_check == []:
         ...
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS521.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS521.md
@@ -3,31 +3,33 @@ code: 521
 title: Found wrong `is` compare
 ---
 
+Forbid comparing values with constants using `is` or `is not`.
 
-Forbid comparing values with constants using ``is`` or ``is not``.
+However, we allow to compare with `None` and booleans.
 
-However, we allow to compare with ``None`` and booleans.
+  - Reasoning:  
+    `is` compares might not do what you want them to do. Firstly, they
+    check for the same object, not equality. Secondly, they behave
+    unexpectedly even with the simple values like `257`.
 
-Reasoning:
-    ``is`` compares might not do what you want them to do.
-    Firstly, they check for the same object, not equality.
-    Secondly, they behave unexpectedly even
-    with the simple values like ``257``.
+  - Solution:  
+    Use `==` to compare with constants.
 
-Solution:
-    Use ``==`` to compare with constants.
-
-Example::
+Example:
 
     # Correct:
     if my_check == [1, 2, 3]:
         ...
-
+    
     # Wrong:
     if my_check is [1, 2, 3]:
         ...
 
-See also:
-    https://stackoverflow.com/a/33130014/4842742
+  - See also:  
+    <https://stackoverflow.com/a/33130014/4842742>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS522.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS522.md
@@ -3,24 +3,26 @@ code: 522
 title: Found implicit primitive in a form of `lambda`
 ---
 
+Forbid implicit primitives in the form of `lambda` functions.
 
-Forbid implicit primitives in the form of ``lambda`` functions.
+  - Reasoning:  
+    When you use `lambda` that returns a primitive value and takes no
+    arguments, it means that you should use a primitive type instead.
 
-Reasoning:
-    When you use ``lambda`` that returns a primitive value
-    and takes no arguments, it means that
-    you should use a primitive type instead.
+  - Solution:  
+    Replace `lambda` with `int`, `float`, `list`, or any other
+    primitive.
 
-Solution:
-    Replace ``lambda`` with ``int``, ``float``,
-    ``list``, or any other primitive.
-
-Example::
+Example:
 
     # Correct:
     defaultdict(int)
-
+    
     # Wrong:
     defaultdict(lambda: 0)
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS523.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS523.md
@@ -3,28 +3,31 @@ code: 523
 title: Found incorrectly swapped variables
 ---
 
-
 Forbid unpythonic variable swaps.
 
-We check for ``a = b; b = a`` sequences.
+We check for `a = b; b = a` sequences.
 
-Reasoning:
+  - Reasoning:  
     This looks like a failed attempt to swap.
 
-Solution:
+  - Solution:  
     Use standard way to swap two variables.
 
-Example::
+Example:
 
     # Correct:
     a, b = b, a
-
+    
     # Wrong:
     a = b
     b = a
-
+    
     temp = a
     a = b
     b = temp
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS524.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS524.md
@@ -3,27 +3,29 @@ code: 524
 title: Found self assignment  with refactored assignment
 ---
 
-
 Forbid misrefactored self assignment.
 
-Reasoning:
-    Self assignment does not need to have the same operand
-    on the left hand side and on the right hand side.
+  - Reasoning:  
+    Self assignment does not need to have the same operand on the left
+    hand side and on the right hand side.
 
-Solution:
+  - Solution:  
     Refactor you code to use multiple self assignments or fix your code.
 
-Example::
+Example:
 
     # Correct:
     test += 1
     test *= 2
-
+    
     # Wrong:
     test += test + 1
 
-See
-:py:data:`~wemake_python_styleguide.constants.MATH_APPROXIMATE_CONSTANTS`
+See :py`~wemake_python_styleguide.constants.MATH_APPROXIMATE_CONSTANTS`
 for full list of math constants that we check for.
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS525.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS525.md
@@ -3,22 +3,25 @@ code: 525
 title: Found wrong `in` compare with single item container
 ---
 
+Forbid comparisons where `in` is compared with single item container.
 
-Forbid comparisons where ``in`` is compared with single item container.
-
-Reasoning:
-    ``in`` comparison with a container which contains only one item looks
+  - Reasoning:  
+    `in` comparison with a container which contains only one item looks
     like overhead and unneeded complexity.
 
-Solution:
-    Refactor your code to use ``==`` instead ``in``.
+  - Solution:  
+    Refactor your code to use `==` instead `in`.
 
-Example::
+Example:
 
     # Correct:
     a == 's'
-
+    
     # Wrong:
     a in {'s'}
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS526.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS526.md
@@ -3,31 +3,32 @@ code: 526
 title: Found implicit `yield from` usage
 ---
 
+Forbid `yield` inside `for` loop instead of `yield from`.
 
-Forbid ``yield`` inside ``for`` loop instead of ``yield from``.
+  - Reasoning:  
+    It is known that `yield from` is a semantically identical to a `for`
+    loop with a `yield` inside. But, it is way more readable.
 
-Reasoning:
-    It is known that ``yield from`` is a semantically identical
-    to a ``for`` loop with a ``yield`` inside.
-    But, it is way more readable.
+  - Solution:  
+    Use `yield from` some iterable directly instead iterating over it
+    inside a loop and `yield` it one by one.
 
-Solution:
-    Use ``yield from`` some iterable directly
-    instead iterating over it inside a loop
-    and ``yield`` it one by one.
-
-Example::
+Example:
 
     # Correct:
     yield from some()
-
+    
     yield from (
         value[index:index + chunk_size]
         for index in range(0, len(value), chunk_size)
     )
-
+    
     # Wrong:
     for index in chunk:
         yield index
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS527.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS527.md
@@ -3,26 +3,28 @@ code: 527
 title: Found not a tuple used as an argument
 ---
 
-
 Require tuples as arguments for certain functions.
 
-Reasoning:
+  - Reasoning:  
     For some functions, it is better to use tuples instead of another
     iterable types (list, sets,...) as arguments.
 
-Solution:
+  - Solution:  
     Use tuples as arguments.
 
-Example::
+Example:
 
     # Correct:
     a = frozenset((2,))
-
+    
     # Wrong:
     a = frozenset([2])
 
-See
-:py:data:`~wemake_python_styleguide.constants.TUPLE_ARGUMENTS_METHODS`
-for full list of methods that we check for.
+See :py`~wemake_python_styleguide.constants.TUPLE_ARGUMENTS_METHODS` for
+full list of methods that we check for.
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS528.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS528.md
@@ -3,26 +3,29 @@ code: 528
 title: Found implicit `.items()` usage
 ---
 
+Forbid implicit `.items()` iterator.
 
-Forbid implicit ``.items()`` iterator.
+  - Reasoning:  
+    When iterating over collection it is easy to forget to use
+    `.items()` when you need to access both keys and values. So, when
+    you access the iterable with the key inside a `for` loop, that's a
+    sign to refactor your code.
 
-Reasoning:
-    When iterating over collection it is easy to forget
-    to use ``.items()`` when you need to access both keys and values.
-    So, when you access the iterable with the key inside a ``for`` loop,
-    that's a sign to refactor your code.
+  - Solution:  
+    Use `.items()` with direct keys and values when you need them.
 
-Solution:
-    Use ``.items()`` with direct keys and values when you need them.
-
-Example::
+Example:
 
     # Correct:
     for some_key, some_value in collection.items():
         print(some_key, some_value)
-
+    
     # Wrong:
     for some_key in collection:
         print(some_key, collection[some_key])
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS529.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS529.md
@@ -3,27 +3,29 @@ code: 529
 title: Found implicit `.get()` dict usage
 ---
 
+Forbid implicit `.get()` dict method.
 
-Forbid implicit ``.get()`` dict method.
+  - Reasoning:  
+    When using `in` with a dict key it is hard to keep the code clean.
+    It is more convenient to use `.get()` and check for `None` later.
 
-Reasoning:
-    When using ``in`` with a dict key it is hard to keep the code clean.
-    It is more convenient to use ``.get()`` and check for ``None`` later.
+  - Solution:  
+    Use `.get()` with the key you need. Check for `None` in case you
+    need it, or just act with the default value of the same type.
 
-Solution:
-    Use ``.get()`` with the key you need.
-    Check for ``None`` in case you need it,
-    or just act with the default value of the same type.
-
-Example::
+Example:
 
     # Correct:
     value = collection.get(key)
     if value is not None:
         print(value)
-
+    
     # Wrong:
     if key in collection:
         print(collection[key])
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS530.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS530.md
@@ -3,23 +3,26 @@ code: 530
 title: Found implicit negative index
 ---
 
-
 Forbid implicit negative indexes.
 
-Reasoning:
-    There's no need in getting the length of an iterable
-    and then having a negative offset,
-    when you can specify negative indexes in the first place.
+  - Reasoning:  
+    There's no need in getting the length of an iterable and then having
+    a negative offset, when you can specify negative indexes in the
+    first place.
 
-Solution:
+  - Solution:  
     Use negative indexes.
 
-Example::
+Example:
 
     # Correct:
     some_list[-1]
-
+    
     # Wrong:
     some_list[len(some_list) - 1]
 
-.. versionadded:: 0.13.0
+<div class="versionadded">
+
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS531.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS531.md
@@ -3,24 +3,24 @@ code: 531
 title: Found simplifiable returning `if` condition in a function
 ---
 
+Forbid if statements that simply return booleans in functions or
+methods.
 
-Forbid if statements that simply return booleans in functions or methods.
-
-Reasoning:
+  - Reasoning:  
     There is no need to test a condition and simply return a boolean
     depending on its outcome if there is not going to be any additional
     code.
 
-Solution:
+  - Solution:  
     Instead of testing the condition and returning a boolean, return the
     condition itself. This applies to early returning ifs too.
 
-Example::
+Example:
 
     # Correct:
     def some_function():
         return some_condition
-
+    
     # Wrong:
     def some_function():
         if some_condition:
@@ -28,4 +28,8 @@ Example::
         else:
             return False
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS600.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS600.md
@@ -3,32 +3,39 @@ code: 600
 title: 'Found subclassing a builtin: {0}'
 ---
 
-
 Forbid subclassing lowercase builtins.
 
-We forbid to subclass builtins like ``int``, ``str``, ``bool``, etc.
-We allow to subclass ``object`` and ``type``, warnings, and exceptions.
+We forbid to subclass builtins like `int`, `str`, `bool`, etc. We allow
+to subclass `object` and `type`, warnings, and exceptions.
 
-See
-:py:data:`~wemake_python_styleguide.constants.ALLOWED_BUILTIN_CLASSES`
-for the whole list of whitelisted names.
+See :py`~wemake_python_styleguide.constants.ALLOWED_BUILTIN_CLASSES` for
+the whole list of whitelisted names.
 
-Reasoning:
-    It is almost never a good idea (unless you do something sneaky)
-    to subclass primitive builtins.
+  - Reasoning:  
+    It is almost never a good idea (unless you do something sneaky) to
+    subclass primitive builtins.
 
-Solution:
-    Use custom objects around some wrapper.
-    Use magic methods to emulate the desired behaviour.
+  - Solution:  
+    Use custom objects around some wrapper. Use magic methods to emulate
+    the desired behaviour.
 
-Example::
+Example:
 
     # Correct:
     class Some(object): ...
     class MyValueException(ValueError): ...
-
+    
     # Wrong:
     class MyInt(int): ...
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS601.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS601.md
@@ -3,47 +3,60 @@ code: 601
 title: 'Found shadowed class attribute: {0}'
 ---
 
-
 Forbid shadowing class level attributes with instance level attributes.
 
-Reasoning:
-    This way you will have two attributes inside your ``__mro__`` chain:
+  - Reasoning:  
+    This way you will have two attributes inside your `__mro__` chain:
     one from instance and one from class. It might cause errors.
     Needless to say, that this is just pointless to do so.
+    
+    Also, if you ever want to optimise your code with a tool like
+    [mypyc](https://github.com/python/mypy/tree/master/mypyc), this rule
+    is a requirement.
 
-    Also, if you ever want to optimise your code with a tool like `mypyc`_,
-    this rule is a requirement.
+  - Solution:  
+    Use either class attributes or instance attributes. Use `ClassVar`
+    type on fields that are declared as class attributes.
 
-Solution:
-    Use either class attributes or instance attributes.
-    Use ``ClassVar`` type on fields that are declared as class attributes.
+Note, that we cannot find shadowed attributes that are defined in parent
+classes. That's where `ClassVar` is required for `mypy` to check it for
+you.
 
-Note, that we cannot find shadowed attributes that are defined
-in parent classes. That's where ``ClassVar`` is required for ``mypy``
-to check it for you.
-
-Example::
+Example:
 
     # Correct:
     from typing import ClassVar
-
+    
     class First(object):
         field: ClassVar[int] = 1
-
+    
     class Second(object):
         field: int
-
+    
         def __init__(self) -> None:
             self.field = 1
-
+    
     # Wrong:
     class Some(object):
         field = 1
-
+    
         def __init__(self) -> None:
             self.field = 1
 
-.. versionadded:: 0.10.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.14.0
-.. _mypyc: https://github.com/python/mypy/tree/master/mypyc
+<div class="versionadded">
+
+0.10.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.14.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS602.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS602.md
@@ -3,15 +3,23 @@ code: 602
 title: Found using `@staticmethod`
 ---
 
+Forbid `@staticmethod` decorator.
 
-Forbid ``@staticmethod`` decorator.
+  - Reasoning:  
+    Static methods are not required to be inside the class. Because they
+    even do not have access to the current instance.
 
-Reasoning:
-    Static methods are not required to be inside the class.
-    Because they even do not have access to the current instance.
+  - Solution:  
+    Use instance methods, `@classmethod`, or functions instead.
 
-Solution:
-    Use instance methods, ``@classmethod``, or functions instead.
+<div class="versionadded">
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.11.0
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS603.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS603.md
@@ -3,24 +3,31 @@ code: 603
 title: 'Found using restricted magic method: {0}'
 ---
 
-
 Forbid certain magic methods.
 
-Reasoning:
-    We forbid to use magic methods related to the forbidden language parts.
-    Likewise, we forbid to use ``del`` keyword, so we forbid to use all
-    magic methods related to it.
+  - Reasoning:  
+    We forbid to use magic methods related to the forbidden language
+    parts. Likewise, we forbid to use `del` keyword, so we forbid to use
+    all magic methods related to it.
 
-Solution:
-    Refactor your code to use custom methods instead.
-    It will give more context to your app.
+  - Solution:  
+    Refactor your code to use custom methods instead. It will give more
+    context to your app.
 
-See
-:py:data:`~wemake_python_styleguide.constants.MAGIC_METHODS_BLACKLIST`
-for the full blacklist of the magic methods.
+See :py`~wemake_python_styleguide.constants.MAGIC_METHODS_BLACKLIST` for
+the full blacklist of the magic methods.
 
-.. versionadded:: 0.1.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
 
-See also:
-    https://www.youtube.com/watch?v=F6u5rhUQ6dU
+0.1.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+  - See also:  
+    <https://www.youtube.com/watch?v=F6u5rhUQ6dU>

--- a/docs/wemake-python-styleguide/0.15.2/WPS604.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS604.md
@@ -3,30 +3,38 @@ code: 604
 title: Found incorrect node inside `class` body
 ---
 
+Forbid incorrect nodes inside `class` definitions.
 
-Forbid incorrect nodes inside ``class`` definitions.
+  - Reasoning:  
+    Python allows us to have conditions, context managers, and even
+    infinite loops inside `class` definitions. On the other hand, only
+    methods, attributes, and docstrings make sense. So, we discourage
+    using anything except these nodes in class bodies.
 
-Reasoning:
-    Python allows us to have conditions, context managers,
-    and even infinite loops inside ``class`` definitions.
-    On the other hand, only methods, attributes, and docstrings make sense.
-    So, we discourage using anything except these nodes in class bodies.
+  - Solution:  
+    If you have complex logic inside your class definition, most likely
+    that you do something wrong. There are different options to refactor
+    this mess. You can try metaclasses, decorators, builders, and other
+    patterns.
 
-Solution:
-    If you have complex logic inside your class definition,
-    most likely that you do something wrong.
-    There are different options to refactor this mess.
-    You can try metaclasses, decorators, builders, and other patterns.
-
-Example::
+Example:
 
     # Wrong:
     class Test(object):
         for _ in range(10):
             print('What?!')
 
-We also allow some nested classes,
-check out :class:`NestedClassViolation` for more information.
+We also allow some nested classes, check out `NestedClassViolation` for
+more information.
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS605.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS605.md
@@ -3,29 +3,36 @@ code: 605
 title: 'Found method without arguments: {0}'
 ---
 
-
 Forbid methods without any arguments.
 
-Reasoning:
-    Methods without arguments are allowed to be defined,
-    but almost impossible to use.
-    Furthermore, they don't have an access to ``self``,
-    so cannot access the inner state of the object.
-    It might be an intentional design or just a typo.
+  - Reasoning:  
+    Methods without arguments are allowed to be defined, but almost
+    impossible to use. Furthermore, they don't have an access to `self`,
+    so cannot access the inner state of the object. It might be an
+    intentional design or just a typo.
 
-Solution:
-    Move any methods with arguments to raw functions.
-    Or just add an argument if it is actually required.
+  - Solution:  
+    Move any methods with arguments to raw functions. Or just add an
+    argument if it is actually required.
 
-Example::
+Example:
 
     # Correct:
     class Test(object):
         def method(self): ...
-
+    
     # Wrong:
     class Test(object):
         def method(): ...
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS606.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS606.md
@@ -3,31 +3,49 @@ code: 606
 title: Found incorrect base class
 ---
 
-
 Forbid anything other than a class as a base class.
 
-We only check base classes and not keywords. They can be anything you need.
+We only check base classes and not keywords. They can be anything you
+need.
 
-Reasoning:
-    In Python you can specify anything in the base classes slot.
-    In runtime this expression will be evaluated and executed.
-    We need to prevent dirty hacks in this field.
+  - Reasoning:  
+    In Python you can specify anything in the base classes slot. In
+    runtime this expression will be evaluated and executed. We need to
+    prevent dirty hacks in this field.
 
-Solution:
-    Use only attributes, names, and types to be your base classes.
-    Use ``annotation`` future import in case
-    you use strings in base classes.
+  - Solution:  
+    Use only attributes, names, and types to be your base classes. Use
+    `annotation` future import in case you use strings in base classes.
 
-Example::
+Example:
 
     # Correct:
     class Test(module.ObjectName, MixinName, keyword=True): ...
     class GenericClass(Generic[ValueType]): ...
-
+    
     # Wrong:
     class Test((lambda: object)()): ...
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.7.1
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.7.1
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS607.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS607.md
@@ -3,41 +3,56 @@ code: 607
 title: Found incorrect `__slots__` syntax
 ---
 
-
-Forbid incorrect ``__slots__`` definition.
+Forbid incorrect `__slots__` definition.
 
 Things that this rule checks:
 
-- That ``__slots__`` is a tuple, name, attribute, star, or call
-- That ``__slots__`` do not have duplicates
-- That ``__slots__`` do not have empty strings or invalid python names
+  - That `__slots__` is a tuple, name, attribute, star, or call
+  - That `__slots__` do not have duplicates
+  - That `__slots__` do not have empty strings or invalid python names
 
-Reasoning:
-    ``__slots__`` is a very special attribute.
-    It completely changes your class. So, we need to be careful with it.
-    We should not allow anything rather than tuples to define slots,
-    we also need to check that fields defined in ``__slots__`` are unique.
+<!-- end list -->
 
-Solution:
-    Use tuples with unique elements to define ``__slots__`` attribute.
-    Use ``snake_case`` to define attributes in ``__slots__``.
+  - Reasoning:  
+    `__slots__` is a very special attribute. It completely changes your
+    class. So, we need to be careful with it. We should not allow
+    anything rather than tuples to define slots, we also need to check
+    that fields defined in `__slots__` are unique.
 
-Example::
+  - Solution:  
+    Use tuples with unique elements to define `__slots__` attribute. Use
+    `snake_case` to define attributes in `__slots__`.
+
+Example:
 
     # Correct:
     class Test(object):
         __slots__ = ('field1', 'field2')
-
+    
     class Other(Test):
         __slots__ = (*Test.__slots__, 'child')
-
+    
     # Wrong:
     class Test(object):
         __slots__ = ['field1', 'field2', 'field2']
 
-Note, that we do ignore all complex expressions for this field.
-So, we only check raw literals.
+Note, that we do ignore all complex expressions for this field. So, we
+only check raw literals.
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS608.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS608.md
@@ -3,25 +3,32 @@ code: 608
 title: 'Found incorrect `super()` call: {0}'
 ---
 
+Forbid `super()` with parameters or outside of methods.
 
-Forbid ``super()`` with parameters or outside of methods.
+  - Reasoning:  
+    `super()` is a very special function. It implicitly relies on the
+    context where it is used and parameters passed to it. So, we should
+    be very careful with parameters and context.
 
-Reasoning:
-    ``super()`` is a very special function.
-    It implicitly relies on the context where it is used
-    and parameters passed to it.
-    So, we should be very careful with parameters and context.
+  - Solution:  
+    Use `super()` without arguments and only inside methods.
 
-Solution:
-    Use ``super()`` without arguments and only inside methods.
-
-Example::
+Example:
 
     # Correct:
     super().__init__()
-
+    
     # Wrong:
     super(ClassName, self).__init__()
 
-.. versionadded:: 0.7.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.7.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS609.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS609.md
@@ -3,29 +3,38 @@ code: 609
 title: 'Found direct magic attribute usage: {0}'
 ---
 
-
 Forbid direct magic attributes and methods.
 
-Reasoning:
-    When using direct magic attributes or method
-    it means that you are doing something wrong.
-    Magic methods are not suited to be directly called or accessed.
+  - Reasoning:  
+    When using direct magic attributes or method it means that you are
+    doing something wrong. Magic methods are not suited to be directly
+    called or accessed.
 
-Solution:
-    Use special syntax constructs that will call underlying magic methods.
+  - Solution:  
+    Use special syntax constructs that will call underlying magic
+    methods.
 
-Example::
+Example:
 
     # Correct:
     super().__init__()
-
+    
     # Wrong:
     2..__truediv__(2)
     d.__delitem__('a')
 
-Note, that it is possible to use direct magic attributes with
-``self``, ``cls``, and ``super()`` as base names.
-We allow this because a lot of internal logic relies on these methods.
+Note, that it is possible to use direct magic attributes with `self`,
+`cls`, and `super()` as base names. We allow this because a lot of
+internal logic relies on these methods.
 
-.. versionadded:: 0.8.0
-.. versionchanged:: 0.11.0
+<div class="versionadded">
+
+0.8.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS610.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS610.md
@@ -3,34 +3,37 @@ code: 610
 title: 'Found forbidden `async` magic method usage: {0}'
 ---
 
-
 Forbid certain async magic methods.
 
-We allow to make ``__anext__``, ``__aenter__``, ``__aexit__`` async.
-We also allow custom magic methods to be async.
+We allow to make `__anext__`, `__aenter__`, `__aexit__` async. We also
+allow custom magic methods to be async.
 
 See
-:py:data:`~wemake_python_styleguide.constants.ASYNC_MAGIC_METHODS_BLACKLIST`
+:py`~wemake_python_styleguide.constants.ASYNC_MAGIC_METHODS_BLACKLIST`
 for the whole list of blacklisted async magic methods.
 
-Reasoning:
-    Defining the magic methods as async which are not supposed
-    to be async would not work as expected.
+  - Reasoning:  
+    Defining the magic methods as async which are not supposed to be
+    async would not work as expected.
 
-Solution:
+  - Solution:  
     Do not make this magic method async.
 
-Example::
+Example:
 
     # Correct:
     class Test(object):
         def __lt__(self, other): ...
-
+    
     # Wrong:
     class Test(object):
         async def __lt__(self, other): ...
 
-See also:
-    https://docs.python.org/3/reference/datamodel.html
+  - See also:  
+    <https://docs.python.org/3/reference/datamodel.html>
 
-.. versionadded:: 0.12.0
+<div class="versionadded">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS611.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS611.md
@@ -3,38 +3,48 @@ code: 611
 title: Found forbidden `yield` magic method usage
 ---
 
+Forbid `yield` inside of certain magic methods.
 
-Forbid ``yield`` inside of certain magic methods.
-
-We allow to make ``__iter__`` a generator.
-See
-:py:data:`~wemake_python_styleguide.constants.YIELD_MAGIC_METHODS_BLACKLIST`
+We allow to make `__iter__` a generator. See
+:py`~wemake_python_styleguide.constants.YIELD_MAGIC_METHODS_BLACKLIST`
 for the whole list of blacklisted generator magic methods.
 
-Reasoning:
-    Python's datamodel is strict.
-    You cannot make generators from random magic methods.
-    This rule enforces it.
+  - Reasoning:  
+    Python's datamodel is strict. You cannot make generators from random
+    magic methods. This rule enforces it.
 
-Solution:
-    Remove ``yield`` from a magic method
-    or rename it to be a custom method.
+  - Solution:  
+    Remove `yield` from a magic method or rename it to be a custom
+    method.
 
-Example::
+Example:
 
-     # Correct:
-    class Example(object):
-        def __init__(self):
-            ...
+    # Correct:
 
-    # Wrong:
-    class Example(object):
-        def __init__(self):
-            yield 10
+>   - class Example(object):
+>     
+>       - def \_\_init\_\_(self):  
+>         ...
+> 
+> \# Wrong: class Example(object): def \_\_init\_\_(self): yield 10
 
-See also:
-    https://docs.python.org/3/reference/datamodel.html
+  - See also:  
+    <https://docs.python.org/3/reference/datamodel.html>
 
-.. versionadded:: 0.3.0
-.. versionchanged:: 0.11.0
-.. versionchanged:: 0.12.0
+<div class="versionadded">
+
+0.3.0
+
+</div>
+
+<div class="versionchanged">
+
+0.11.0
+
+</div>
+
+<div class="versionchanged">
+
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS612.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS612.md
@@ -3,29 +3,31 @@ code: 612
 title: 'Found useless overwritten method: {0}'
 ---
 
-
 Forbid useless overwritten methods.
 
-Reasoning:
-    Overwriting method without any changes
-    does not have any positive impact.
+  - Reasoning:  
+    Overwriting method without any changes does not have any positive
+    impact.
 
-Solution:
-    Do not overwrite method in case you do not want
-    to do any changes inside it.
+  - Solution:  
+    Do not overwrite method in case you do not want to do any changes
+    inside it.
 
-Example::
+Example:
 
     # Correct:
     class Test(Base):
         def method(self, argument):
             super().method(argument)
             return argument  # or None, or anything!
-
+    
     # Wrong:
     class Test(object):
         def method(self, argument):
             return super().method(argument)
 
+<div class="versionadded">
 
-.. versionadded:: 0.12.0
+0.12.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS613.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS613.md
@@ -3,28 +3,30 @@ code: 613
 title: 'Found incorrect `super()` call context: incorrect name access'
 ---
 
+Forbid `super()` with incorrect method or property access.
 
-Forbid ``super()`` with incorrect method or property access.
+  - Reasoning:  
+    Can only use `super()` method that matches the following context.
+    `super().some()` and `super().some` in `Child.some()`, and
+    `super().prop` and `super().prop()` in `Child.prop`
 
-Reasoning:
-    Can only use ``super()`` method that matches the following context.
-    ``super().some()`` and ``super().some`` in ``Child.some()``,
-    and ``super().prop`` and ``super().prop()`` in ``Child.prop``
+  - Solution:  
+    Use `super()` methods and properties with the correct context.
 
-Solution:
-    Use ``super()`` methods and properties with the correct context.
-
-Example::
+Example:
 
     # Correct:
     class Child(Parent):
         def some_method(self):
             original = super().some_method()
-
+    
     # Wrong:
     class Child(Parent):
         def some_method(self):
             other = super().other_method()
 
+<div class="versionadded">
 
-.. versionadded:: 0.13.0
+0.13.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS614.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS614.md
@@ -3,32 +3,35 @@ code: 614
 title: Found descriptor applied on a function
 ---
 
-
 Forbids descriptors in regular functions.
 
-Forbids using `@staticmethod`, ``@classmethod`` and ``@property`` for
-functions not in class.
+Forbids using <span class="title-ref">@staticmethod</span>,
+`@classmethod` and `@property` for functions not in class.
 
-Reasoning:
+  - Reasoning:  
     Descriptors like @staticmethod, @classmethod and @property do magic
     only as methods. We would want to warn users if the descriptors are
     used on regular functions.
 
-Solution:
+  - Solution:  
     Do not use @staticmethod, @classmethod and @property on regular
     functions or wrap the functions into a Class.
 
-Example::
+Example:
 
     # Correct:
     class TestClass(object):
         @property
         def my_method():
             ...
-
+    
     # Wrong:
     @property
     def my_function():
         ...
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/docs/wemake-python-styleguide/0.15.2/WPS615.md
+++ b/docs/wemake-python-styleguide/0.15.2/WPS615.md
@@ -3,32 +3,35 @@ code: 615
 title: Found unpythonic getter or setter
 ---
 
-
 Forbids to use getters and setters in objects.
 
-Reasoning:
+  - Reasoning:  
     Python does not need this abstraction.
 
-Solution:
-    Either use ``@property`` or make the
-    attribute public and change it directly.
+  - Solution:  
+    Either use `@property` or make the attribute public and change it
+    directly.
 
-Example::
+Example:
 
     # Correct:
     class Example(object):
         def __init__(self):
             self._attribute = None
-
+    
     # Wrong:
     class Example(object):
         def __init__(self):
             self.attribute = None
-
+    
         def set_attribute(self):
             ...
-
+    
         def get_attribute(self, value):
             ...
 
-.. versionadded:: 0.15.0
+<div class="versionadded">
+
+0.15.0
+
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,3 +30,5 @@ theme:
   features:
     - navigation.tabs
     - header.autohide
+    - navigation.sections
+    - navigation.indexes

--- a/poetry.lock
+++ b/poetry.lock
@@ -773,6 +773,14 @@ python-versions = ">=3.6"
 Markdown = ">=3.2"
 
 [[package]]
+name = "pypandoc"
+version = "1.5"
+description = "Thin wrapper for pandoc."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
@@ -1032,7 +1040,7 @@ typing_extensions = ">=3.6,<4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.9"
-content-hash = "b8a636decb6de01b751f2eaa21093dbf591ffeb22899c62e2aca7efbe81d4c83"
+content-hash = "39e0d253b8d9320fbd0d8970a283e98a9e9053db7ab21af36217e5144bc82d20"
 
 [metadata.files]
 astor = [
@@ -1416,6 +1424,9 @@ pyld = [
 pymdown-extensions = [
     {file = "pymdown-extensions-8.1.1.tar.gz", hash = "sha256:632371fa3bf1b21a0e3f4063010da59b41db049f261f4c0b0872069a9b6d1735"},
     {file = "pymdown_extensions-8.1.1-py3-none-any.whl", hash = "sha256:478b2c04513fbb2db61688d5f6e9030a92fb9be14f1f383535c43f7be9dff95b"},
+]
+pypandoc = [
+    {file = "pypandoc-1.5.tar.gz", hash = "sha256:14a49977ab1fbc9b14ef3087dcb101f336851837fca55ca79cf33846cc4976ff"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ mkautodoc = "^0.1.0"
 wemake-python-styleguide = "^0.15.2"
 flakehell = "^0.9.0"
 pydantic = "^1.8.1"
+pypandoc = "^1.5"
 
 
 [tool.poetry.dev-dependencies]

--- a/run.py
+++ b/run.py
@@ -23,7 +23,13 @@ class Violation(BaseModel):
 
 def format_violation_description(description: str) -> str:
     """Format violation description properly."""
+    # The description is originally a docstring, need to remote indentation.
     description = textwrap.dedent(description)
+
+    # Sometimes `{{` is met in Python examples, which breaks Jinja2 templating.
+    description = description.replace(
+        '{{', "{{ '{{' }}",
+    )
 
     return pypandoc.convert_text(
         source=description,

--- a/run.py
+++ b/run.py
@@ -1,59 +1,85 @@
+import concurrent.futures
 import textwrap
 from importlib import import_module
 from pathlib import Path
+from typing import Type
 
 import frontmatter
+import pypandoc
 from pydantic import Field, BaseModel, validator
 from wemake_python_styleguide import violations
 from wemake_python_styleguide.version import pkg_version
+from wemake_python_styleguide.violations.base import BaseViolation
 
 
 class Violation(BaseModel):
     """Violation description."""
 
-    code: int = Field(title='Error Code.')
+    code: int
     title: str
-    description: str = ''
+    description: str
+    output_file: Path
 
-    @validator('description')
-    def validate_description(cls, description: str) -> str:
-        """Format the description."""
-        return textwrap.dedent(description)
+
+def format_violation_description(description: str) -> str:
+    """Format violation description properly."""
+    description = textwrap.dedent(description)
+
+    return pypandoc.convert_text(
+        source=description,
+        to='commonmark',
+        format='rst',
+    )
+
+
+def generate_violation_file(violation: Violation) -> None:
+    """Store violation description into a Markdown file with meta."""
+    # Here is the heavy I/O operation with pandoc
+    description = format_violation_description(violation.description)
+
+    md = frontmatter.Post(
+        content=description,
+        handler=frontmatter.YAMLHandler(),
+        **violation.dict(include={'code', 'title'}),
+    )
+
+    with open(violation.output_file, 'wb+') as code_file:
+        frontmatter.dump(md, code_file)
 
 
 def generate_wps():
-    version_directory = Path(__file__).parent / 'docs/wemake-python-styleguide' / pkg_version
+    version_directory = Path(
+        __file__,
+    ).parent / 'docs/wemake-python-styleguide' / pkg_version
     version_directory.mkdir(parents=True, exist_ok=True)
 
-    # This code is from flakehell
-    codes = dict()
-    for path in Path(violations.__path__[0]).iterdir():
-        module = import_module('wemake_python_styleguide.violations.' + path.stem)
-        for checker_name in dir(module):
-            if not checker_name.endswith('Violation'):
-                continue
-            checker = getattr(module, checker_name)
-            if not hasattr(checker, 'code'):
-                continue
-            code = 'WPS' + str(checker.code).zfill(3)
-            codes[code] = checker.error_template
-
-            violation = Violation(
-                code=checker.code,
-                title=checker.error_template,
-                description=checker.__doc__,
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        # This cycle is adapted from flakehell
+        for path in Path(violations.__path__[0]).iterdir():
+            module = import_module(
+                'wemake_python_styleguide.violations.' + path.stem,
             )
+            for checker_name in dir(module):
+                if not checker_name.endswith('Violation'):
+                    continue
+                checker = getattr(module, checker_name)
+                if not hasattr(checker, 'code'):
+                    continue
 
-            md = frontmatter.Post(
-                content=violation.description,
-                handler=frontmatter.YAMLHandler(),
-                **violation.dict(include={'title', 'code'}),
-            )
+                code = checker.code
+                output_file = version_directory / f'WPS{code:03}.md'
 
-            with open(version_directory / f'{code}.md', 'wb+') as code_file:
-                frontmatter.dump(md, code_file)
+                violation = Violation(
+                    code=code,
+                    title=checker.error_template,
+                    description=checker.__doc__,
+                    output_file=output_file,
+                )
 
-    return codes
+                executor.submit(
+                    generate_violation_file,
+                    violation,
+                )
 
 
 def main():


### PR DESCRIPTION
- Convert ReST markup in wemake-python-styleguide into Markdown using pandoc + pypandoc and threading
- Fix Jinja2 template error
- Remedy the error with ` quotes
